### PR TITLE
Add option to resume playback on headphones insertion.

### DIFF
--- a/ultrasonic/src/main/res/values-es/strings.xml
+++ b/ultrasonic/src/main/res/values-es/strings.xml
@@ -249,6 +249,8 @@
     <string name="settings.preload_3">3 canciónes</string>
     <string name="settings.preload_5">5 canciónes</string>
     <string name="settings.preload_unlimited">Ilimitado</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.title">Reanudación de la inserción de auriculares</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.summary">La aplicación reanudará la reproducción en pausa al insertar los auriculares en el dispositivo.</string>
     <string name="settings.screen_lit_summary">Mantener la pantalla encendida mientras descarga mejora la velocidad de la misma.</string>
     <string name="settings.screen_lit_title">Mantener la pantalla encendida</string>
     <string name="settings.scrobble_summary">Recuerda configurar tu nombre de usuario y contraseña de Last.fm en el servidor de Subsonic</string>

--- a/ultrasonic/src/main/res/values-fr/strings.xml
+++ b/ultrasonic/src/main/res/values-fr/strings.xml
@@ -249,6 +249,8 @@
     <string name="settings.preload_3">3 morceaux</string>
     <string name="settings.preload_5">5 morceaux</string>
     <string name="settings.preload_unlimited">Illimité</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.title">Reprise de l\'insertion des écouteurs</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.summary">L\'application reprendra la lecture en pause lors de l\'insertion du casque dans l\'appareil.</string>
     <string name="settings.screen_lit_summary">Garder l\'écran allumé pendant le téléchargement permet d\'améliorer la vitesse de téléchargement.</string>
     <string name="settings.screen_lit_title">Garder écran allumé</string>
     <string name="settings.scrobble_summary">N\'oubliez pas de définir votre nom d\'utilisateur et mot de passe Last.fm sur le serveur Subsonic</string>

--- a/ultrasonic/src/main/res/values-hu/strings.xml
+++ b/ultrasonic/src/main/res/values-hu/strings.xml
@@ -249,6 +249,8 @@
     <string name="settings.preload_3">3 dal</string>
     <string name="settings.preload_5">5 dal</string>
     <string name="settings.preload_unlimited">Korlátlan</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.title">Folytatás a fejhallgató behelyezésekor</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.summary">Az alkalmazás folytatja a szüneteltetett lejátszást a fejhallgató behelyezésekor a készülékbe.</string>
     <string name="settings.screen_lit_summary">Képernyő ébrentartása a letöltés alatt, a magasabb letöltési sebesség érdekében.</string>
     <string name="settings.screen_lit_title">Képernyő ébrentartása</string>
     <string name="settings.scrobble_summary">A Last.fm felhasználónevet és jelszót be kell állítani a Subsonic kiszolgálón!</string>

--- a/ultrasonic/src/main/res/values-pt-rBR/strings.xml
+++ b/ultrasonic/src/main/res/values-pt-rBR/strings.xml
@@ -252,6 +252,8 @@
     <string name="settings.preload_3">3 músicas</string>
     <string name="settings.preload_5">5 músicas</string>
     <string name="settings.preload_unlimited">Ilimitado</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.title">Currículo na inserção de fone de ouvido</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.summary">O aplicativo retomará a reprodução em pausa na inserção dos fones de ouvido no dispositivo.</string>
     <string name="settings.screen_lit_summary">Manter a tela ligada enquanto baixando aumenta a velocidade de download.</string>
     <string name="settings.screen_lit_title">Manter a Tela Ligada</string>
     <string name="settings.scrobble_summary">Lembre-se de definir seu usuário e senha do Last.fm no servidor Subsonic</string>

--- a/ultrasonic/src/main/res/values-pt/strings.xml
+++ b/ultrasonic/src/main/res/values-pt/strings.xml
@@ -252,6 +252,8 @@
     <string name="settings.preload_3">3 músicas</string>
     <string name="settings.preload_5">5 músicas</string>
     <string name="settings.preload_unlimited">Ilimitado</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.title">Currículo na inserção de fone de ouvido</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.summary">O aplicativo retomará a reprodução em pausa na inserção dos fones de ouvido no dispositivo.</string>
     <string name="settings.screen_lit_summary">Manter o ecrã ligado enquanto descarrega aumenta a velocidade de download.</string>
     <string name="settings.screen_lit_title">Manter o Ecrã Ligado</string>
     <string name="settings.scrobble_summary">Lembre-se de definir seu usuário e senha do Last.fm no servidor Subsonic</string>

--- a/ultrasonic/src/main/res/values/playback_preferences_keys.xml
+++ b/ultrasonic/src/main/res/values/playback_preferences_keys.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="settings.playback.resume_play_on_headphones_plug" translatable="false">playback.resume_play_on_headphones_plug</string>
+</resources>

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -253,6 +253,8 @@
     <string name="settings.preload_3">3 songs</string>
     <string name="settings.preload_5">5 songs</string>
     <string name="settings.preload_unlimited">Unlimited</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.title">Resume on headphones insertion</string>
+    <string name="settings.playback.resume_play_on_headphones_plug.summary">App will resume paused playback on headphones insertion into device.</string>
     <string name="settings.screen_lit_summary">Keeping the screen on while downloading improves download speed.</string>
     <string name="settings.screen_lit_title">Keep Screen On</string>
     <string name="settings.scrobble_summary">Remember to set up your Last.fm user and password on the Subsonic server</string>

--- a/ultrasonic/src/main/res/xml/settings.xml
+++ b/ultrasonic/src/main/res/xml/settings.xml
@@ -100,6 +100,12 @@
             a:entryValues="@array/incrementTimeValues"
             a:key="incrementTime"
             a:title="@string/settings.increment_time"/>
+        <CheckBoxPreference
+            a:defaultValue="false"
+            a:key="@string/settings.playback.resume_play_on_headphones_plug"
+            a:title="@string/settings.playback.resume_play_on_headphones_plug.title"
+            a:summary="@string/settings.playback.resume_play_on_headphones_plug.summary"
+            />
     </PreferenceCategory>
     <PreferenceCategory a:title="@string/settings.notifications_title">
         <CheckBoxPreference


### PR DESCRIPTION
This is disabled by default and should be enabled in app settings.
Playback resume only happened when app is not in Jukebox mode and
playback is paused.

Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>

Closes #93 