### PR TITLE
 Added Transifex automation for localizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,4 +66,9 @@ workflows:
       - push_translations:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - develop
+                - master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,4 +38,32 @@ jobs:
           destination: reports
       - store_artifacts:
           path: build/reports/jacoco/jacocoFullReport/
+  push_translations:
+    docker:
+      - image: circleci/python:3.6
+    working_directory: ~/ultrasonic
+    steps:
+      - checkout
+      - run:
+          name: install transifex client
+          command: |
+            python -m venv ~/venv
+            . ~/venv/bin/activate
+            pip install transifex-client
+      - run:
+          name: configure transifex client
+          command: echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = api\npassword = '"${TRANSIFEX_PASSWORD}"$'\n' > ~/.transifexrc
+      - run:
+          name: push changes in translation files
+          command: |
+            . ~/venv/bin/activate
+            tx push -st
+workflows:
+  version: 2
+  build_and_push_translations:
+    jobs:
+      - build
+      - push_translations:
+          requires:
+            - build
 

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,10 @@
+[main]
+host = https://www.transifex.com
+lang_map = fr_CA:fr-rCA,pt_BR:pt-rBR,pt_PT:pt,zh_CN:zh-rCN,zh_HK:zh-rHK,zh_TW:zh-rTW,da_DK:da-rDK,de_DE:de,tr_TR:tr,fr_FR:fr,es_ES:es,hu_HU:hu,sv_SE:sv-rSE,bg_BG:bg,el_GR:el,kn_IN:kn-rIN,cs_CZ:cs,sr:sr,he:iw,id:in,lt_LT:lt,km_KH:km-rKH,th_TH:th
+
+[ultrasonic.app]
+file_filter = ultrasonic/src/main/res/values-<lang>/strings.xml
+source_file = ultrasonic/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID
+

--- a/ultrasonic/src/main/res/values-es/strings.xml
+++ b/ultrasonic/src/main/res/values-es/strings.xml
@@ -14,6 +14,9 @@
     <string name="button_bar.chat">Chat</string>
     <string name="button_bar.home">Inicio de UltraSonic</string>
     <string name="button_bar.now_playing">Reproduciendo ahora</string>
+    <string name="podcasts.label">Podcast</string>
+    <string name="podcasts_channels.empty">No hay canales de Podcasts registrados</string>
+    <string name="button_bar.podcasts">Podcast</string>
     <string name="button_bar.playlists">Listas de reproducción</string>
     <string name="button_bar.search">Buscar</string>
     <string name="chat.send_a_message">Enviar un mensaje</string>
@@ -393,9 +396,7 @@
     <string name="settings.image_loader_concurrency_12">12</string>
     <string name="albumArt">Caratula del Álbum</string>
     <string name="common_multiple_years">Múltiples años</string>
-
     <plurals name="select_album_n_songs">
-        <item quantity="zero">Ninguna canción</item>
         <item quantity="one">1 canción</item>
         <item quantity="other">%d canciones</item>
     </plurals>
@@ -423,9 +424,6 @@
         <item quantity="one">Queda un día de periodo de prueba</item>
         <item quantity="other">Quedan %d días de periodo de prueba</item>
     </plurals>
-    <string name="button_bar.podcasts">Podcast</string>
-    <string name="podcasts.label">Podcast</string>
-    <string name="podcasts_channels.empty">No hay canales de Podcasts registrados</string>
 
     <!-- Subsonic api errors -->
     <string name="api.subsonic.generic">Error genérico de api: %1$s</string>

--- a/ultrasonic/src/main/res/values-fr/strings.xml
+++ b/ultrasonic/src/main/res/values-fr/strings.xml
@@ -14,6 +14,9 @@
     <string name="button_bar.chat">Salon de discussion</string>
     <string name="button_bar.home">Accueil Ultrasonic</string>
     <string name="button_bar.now_playing">Lecture en cours</string>
+    <string name="podcasts.label">Podcast</string>
+    <string name="podcasts_channels.empty">No podcasts channels registered</string>
+    <string name="button_bar.podcasts">Podcast</string>
     <string name="button_bar.playlists">Playlists</string>
     <string name="button_bar.search">Recherche</string>
     <string name="chat.send_a_message">Envoyer un message</string>
@@ -236,8 +239,8 @@
     <string name="settings.network_timeout_60000">60 secondes</string>
     <string name="settings.network_timeout_75000">75 secondes</string>
     <string name="settings.network_timeout_90000">90 secondes</string>
-    <string name="settings.network_title">Réseau</string>
     <string name="settings.notifications_title">Notifications</string>
+    <string name="settings.network_title">Réseau</string>
     <string name="settings.other_title">Autres paramètres</string>
     <string name="settings.playback_control_title">Paramètres de contrôle de lecture</string>
     <string name="settings.preload">Titres à pré-charger</string>
@@ -393,9 +396,7 @@
     <string name="settings.image_loader_concurrency_12">12</string>
     <string name="albumArt">albumArt</string>
     <string name="common_multiple_years">Multiple Years</string>
-
     <plurals name="select_album_n_songs">
-        <item quantity="zero">Aucun titre</item>
         <item quantity="one">Un titre</item>
         <item quantity="other">%d titres</item>
     </plurals>
@@ -423,9 +424,6 @@
         <item quantity="one">Un jour restant à la période d\'essai</item>
         <item quantity="other">%d jours restant à la période d\'essai</item>
     </plurals>
-    <string name="button_bar.podcasts">Podcast</string>
-    <string name="podcasts.label">Podcast</string>
-    <string name="podcasts_channels.empty">No podcasts channels registered</string>
 
     <!-- Subsonic api errors -->
     <string name="api.subsonic.generic">Erreur api générique: %1$s</string>

--- a/ultrasonic/src/main/res/values-hu/strings.xml
+++ b/ultrasonic/src/main/res/values-hu/strings.xml
@@ -14,6 +14,9 @@
     <string name="button_bar.chat">Csevegés (Chat)</string>
     <string name="button_bar.home">UltraSonic főoldal</string>
     <string name="button_bar.now_playing">Lejátszó</string>
+    <string name="podcasts.label">Podcast</string>
+    <string name="podcasts_channels.empty">No podcasts channels registered</string>
+    <string name="button_bar.podcasts">Podcast</string>
     <string name="button_bar.playlists">Lejátszási listák</string>
     <string name="button_bar.search">Keresés</string>
     <string name="chat.send_a_message">Üzenet küldése</string>
@@ -393,9 +396,7 @@
     <string name="settings.image_loader_concurrency_12">12</string>
     <string name="albumArt">albumArt</string>
     <string name="common_multiple_years">Multiple Years</string>
-
     <plurals name="select_album_n_songs">
-        <item quantity="zero">Nincsenek dalok</item>
         <item quantity="one">1 dal</item>
         <item quantity="other">%d dal</item>
     </plurals>
@@ -423,9 +424,6 @@
         <item quantity="one">1 nap van hátra a próba időszakból.</item>
         <item quantity="other">%d nap van hátra a próba időszakból.</item>
     </plurals>
-    <string name="button_bar.podcasts">Podcast</string>
-    <string name="podcasts.label">Podcast</string>
-    <string name="podcasts_channels.empty">No podcasts channels registered</string>
 
     <!-- Subsonic api errors -->
     <string name="api.subsonic.generic">Általános api hiba: %1$s</string>

--- a/ultrasonic/src/main/res/values-pt-rBR/strings.xml
+++ b/ultrasonic/src/main/res/values-pt-rBR/strings.xml
@@ -396,9 +396,7 @@
     <string name="settings.image_loader_concurrency_12">12</string>
     <string name="albumArt">albumArt</string>
     <string name="common_multiple_years">Múltiplos Anos</string>
-
     <plurals name="select_album_n_songs">
-        <item quantity="zero">Nenhuma música</item>
         <item quantity="one">1 música</item>
         <item quantity="other">%d músicas</item>
     </plurals>

--- a/ultrasonic/src/main/res/values-pt/strings.xml
+++ b/ultrasonic/src/main/res/values-pt/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <string name="background_task.loading">Carregando&#8230;</string>
     <string name="background_task.network_error">Ocorreu um erro de rede. Verifique o endereço do servidor ou tente mais tarde.</string>
@@ -396,9 +396,7 @@
     <string name="settings.image_loader_concurrency_12">12</string>
     <string name="albumArt">albumArt</string>
     <string name="common_multiple_years">Múltiplos Anos</string>
-
-    <plurals name="select_album_n_songs" tools:ignore="UnusedQuantity">
-        <item quantity="zero">Nenhuma música</item>
+    <plurals name="select_album_n_songs">
         <item quantity="one">%d música</item>
         <item quantity="other">%d músicas</item>
     </plurals>

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -401,7 +401,6 @@
     <string name="settings.server_address_unset" translatable="false">http://example.com</string>
 
     <plurals name="select_album_n_songs">
-        <item quantity="zero">No songs</item>
         <item quantity="one">1 song</item>
         <item quantity="other">%d songs</item>
     </plurals>


### PR DESCRIPTION
Using CircleCI.

The changes in language files are caused by purals support in Transifex that is standard and is fixed for every language. In this case we passed from `No songs` to `0 songs` that not is a problem.

This automation PUSH new changes in language files to Transifex for the community work on it. But the pull must be done "by hand" using `tx pull` command.

Take note of quotes in "by hand", because is simply execute a command that we can do before every release.