### PR TITLE
Fix inconsistent behaviour when adding new server on debug build.

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Constants.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Constants.java
@@ -131,9 +131,6 @@ public final class Constants
 	public static final String PREFERENCES_KEY_SCAN_MEDIA = "scanMedia";
 	public static final String PREFERENCES_KEY_IMAGE_LOADER_CONCURRENCY = "imageLoaderConcurrency";
 
-	// Name of the preferences file.
-	public static final String PREFERENCES_FILE_NAME = "org.moire.ultrasonic_preferences";
-
 	// Number of free trial days for non-licensed servers.
 	public static final int FREE_TRIAL_DAYS = 30;
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -398,10 +398,9 @@ public class Util extends DownloadActivity
 		return builder.toString();
 	}
 
-	public static SharedPreferences getPreferences(Context context)
-	{
-		return context.getSharedPreferences(Constants.PREFERENCES_FILE_NAME, 0);
-	}
+    public static SharedPreferences getPreferences(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context);
+    }
 
 	public static int getRemainingTrialDays(Context context)
 	{


### PR DESCRIPTION
After adding special suffix for debug builds, default shared preferences
name was changed.

Fixes #187 