### PR TITLE
Fix notification can't be killed when player is not playing.

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
@@ -1094,7 +1094,7 @@ public class DownloadServiceImpl extends Service implements DownloadService
 				}
 				setPlayerState(STOPPED);
 			}
-			else if (playerState == PAUSED)
+			else
 			{
 				setPlayerState(STOPPED);
 			}


### PR DESCRIPTION
Fix clicking on close (x) in notification does nothing when player has
neither playing nor paused state.

Fixes #103 