### PR TITLE
Fix f-droid can't build new app version.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,4 @@
 ext.versions = [
-        versionCode          : 67,
-        versionName          : "2.4.0",
-
         minSdk               : 14,
         targetSdk            : 22,
         compileSdk           : 27,

--- a/ultrasonic/build.gradle
+++ b/ultrasonic/build.gradle
@@ -8,8 +8,8 @@ android {
 
     defaultConfig {
         applicationId "org.moire.ultrasonic"
-        versionCode versions.versionCode
-        versionName versions.versionName
+        versionCode 67
+        versionName "2.4.0"
 
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk


### PR DESCRIPTION
F-Droid has a strict limitation (:disappointed:) that version code and
version name should be in the app build.gradle.