### PR TITLE
Fast and dirty fix to Subsonic 6.1.4

### DIFF
--- a/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIVersions.kt
+++ b/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIVersions.kt
@@ -51,6 +51,7 @@ enum class SubsonicAPIVersions(val subsonicVersions: String, val restApiVersion:
                 "1.14.0" -> return V1_14_0
                 "1.15.0" -> return V1_15_0
                 "1.16.0" -> return V1_16_0
+                "1.16.1" -> return V1_16_0 // Fast and dirty fix to Subsonic 6.1.4
                 else -> throw IllegalArgumentException("Unknown api version $apiVersion")
             }
         }

--- a/ultrasonic/build.gradle
+++ b/ultrasonic/build.gradle
@@ -8,8 +8,8 @@ android {
 
     defaultConfig {
         applicationId "org.moire.ultrasonic"
-        versionCode 69
-        versionName "2.6.0"
+        versionCode 70
+        versionName "2.6.1"
 
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk


### PR DESCRIPTION
Only use the new API level as a lower level. Not is elegant but works as workaround of #238 

@Tapchicoma please give your geen light to merge it to master