### PR TITLE
Feature/upgrade to api28

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/activity/BookmarkActivity.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/activity/BookmarkActivity.java
@@ -206,6 +206,7 @@ public class BookmarkActivity extends SubsonicTabActivity
 		if (!getSelectedSongs(albumListView).isEmpty())
 		{
 			int position = songs.get(0).getBookmarkPosition();
+			if (getDownloadService() == null) return;
 			getDownloadService().restore(songs, 0, position, true, true);
 			selectAll(false, false);
 		}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SubsonicTabActivity.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SubsonicTabActivity.java
@@ -97,11 +97,8 @@ public class SubsonicTabActivity extends ResultActivity implements OnClickListen
 		applyTheme();
 		super.onCreate(bundle);
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			startForegroundService(new Intent(this, DownloadServiceImpl.class));
-		} else {
-			startService(new Intent(this, DownloadServiceImpl.class));
-		}
+		// This should always succeed as it is called when Ultrasonic is in the foreground
+		startService(new Intent(this, DownloadServiceImpl.class));
 		setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
 		if (bundle != null)
@@ -778,10 +775,15 @@ public class SubsonicTabActivity extends ResultActivity implements OnClickListen
 			}
 
 			Log.w(TAG, "DownloadService not running. Attempting to start it.");
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-				startForegroundService(new Intent(this, DownloadServiceImpl.class));
-			} else {
+
+			try
+			{
 				startService(new Intent(this, DownloadServiceImpl.class));
+			}
+			catch (IllegalStateException exception)
+			{
+				Log.w(TAG, "getDownloadService couldn't start DownloadServiceImpl because the application was in the background.");
+				return null;
 			}
 			Util.sleepQuietly(50L);
 		}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
@@ -108,6 +108,13 @@ public class SettingsFragment extends PreferenceFragment
         setupClearSearchPreference();
         setupGaplessControlSettingsV14();
         setupFeatureFlagsPreferences();
+
+        // After API26 foreground services must be used for music playback, and they must have a notification
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PreferenceCategory notificationsCategory = (PreferenceCategory) findPreference(Constants.PREFERENCES_KEY_CATEGORY_NOTIFICATIONS);
+            notificationsCategory.removePreference(findPreference(Constants.PREFERENCES_KEY_SHOW_NOTIFICATION));
+            notificationsCategory.removePreference(findPreference(Constants.PREFERENCES_KEY_ALWAYS_SHOW_NOTIFICATION));
+        }
     }
 
     @Override

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/MediaButtonIntentReceiver.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/MediaButtonIntentReceiver.java
@@ -58,18 +58,19 @@ public class MediaButtonIntentReceiver extends BroadcastReceiver
 
 			Intent serviceIntent = new Intent(context, DownloadServiceImpl.class);
 			serviceIntent.putExtra(Intent.EXTRA_KEY_EVENT, event);
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-				context.startForegroundService(serviceIntent);
-			} else {
-				context.startService(serviceIntent);
-			}
 
 			try
 			{
+				context.startService(serviceIntent);
+
 				if (isOrderedBroadcast())
 				{
 					abortBroadcast();
 				}
+			}
+			catch (IllegalStateException exception)
+			{
+				Log.w(TAG, "MediaButtonIntentReceiver couldn't start DownloadServiceImpl because the application was in the background.");
 			}
 			catch (Exception x)
 			{

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
@@ -264,8 +264,10 @@ public class DownloadServiceImpl extends Service implements DownloadService
 		instance = this;
 		lifecycleSupport.onCreate();
 
+		// Create Notification Channel
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, NOTIFICATION_CHANNEL_NAME, NotificationManager.IMPORTANCE_NONE);
+			//The suggested importance of a startForeground service notification is IMPORTANCE_LOW
+			NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, NOTIFICATION_CHANNEL_NAME, NotificationManager.IMPORTANCE_LOW);
 			channel.setLightColor(android.R.color.holo_blue_dark);
 			channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);
 			NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
@@ -2122,6 +2124,7 @@ public class DownloadServiceImpl extends Service implements DownloadService
         notificationBuilder.setOnlyAlertOnce(true);
         notificationBuilder.setWhen(System.currentTimeMillis());
         notificationBuilder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+		notificationBuilder.setPriority(NotificationCompat.PRIORITY_LOW);
 
         RemoteViews contentView = new RemoteViews(this.getPackageName(), R.layout.notification);
         Util.linkButtons(this, contentView, false);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
@@ -276,13 +276,17 @@ public class DownloadServiceImpl extends Service implements DownloadService
 
 		// We should use a single notification builder, otherwise the notification may not be updated
 		notificationBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID);
+
+		Log.i(TAG, "DownloadServiceImpl created");
 	}
 
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId)
 	{
 		super.onStartCommand(intent, flags, startId);
+
 		lifecycleSupport.onStart(intent);
+		Log.i(TAG, "DownloadServiceImpl started with intent");
 		return START_NOT_STICKY;
 	}
 
@@ -338,6 +342,8 @@ public class DownloadServiceImpl extends Service implements DownloadService
 		catch (Throwable ignored)
 		{
 		}
+
+		Log.i(TAG, "DownloadServiceImpl stopped");
 	}
 
 	public static DownloadService getInstance()
@@ -2144,44 +2150,47 @@ public class DownloadServiceImpl extends Service implements DownloadService
             bigView.setImageViewResource(R.id.control_play, R.drawable.media_pause_normal_dark);
         }
 
-        final Entry song = currentPlaying.getSong();
-        final String title = song.getTitle();
-        final String text = song.getArtist();
-        final String album = song.getAlbum();
-		final int rating = song.getUserRating() == null ? 0 : song.getUserRating();
-        final int imageSize = Util.getNotificationImageSize(this);
+        if (currentPlaying != null) {
+			final Entry song = currentPlaying.getSong();
+			final String title = song.getTitle();
+			final String text = song.getArtist();
+			final String album = song.getAlbum();
+			final int rating = song.getUserRating() == null ? 0 : song.getUserRating();
+			final int imageSize = Util.getNotificationImageSize(this);
 
-        try {
-            final Bitmap nowPlayingImage = FileUtil.getAlbumArtBitmap(this, currentPlaying.getSong(), imageSize, true);
-            if (nowPlayingImage == null) {
-                contentView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
-                bigView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
-            } else {
-                contentView.setImageViewBitmap(R.id.notification_image, nowPlayingImage);
-                bigView.setImageViewBitmap(R.id.notification_image, nowPlayingImage);
-            }
-        } catch (Exception x) {
-            Log.w(TAG, "Failed to get notification cover art", x);
-            contentView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
-            bigView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
-        }
+			try {
+				final Bitmap nowPlayingImage = FileUtil.getAlbumArtBitmap(this, currentPlaying.getSong(), imageSize, true);
+				if (nowPlayingImage == null) {
+					contentView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
+					bigView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
+				} else {
+					contentView.setImageViewBitmap(R.id.notification_image, nowPlayingImage);
+					bigView.setImageViewBitmap(R.id.notification_image, nowPlayingImage);
+				}
+			} catch (Exception x) {
+				Log.w(TAG, "Failed to get notification cover art", x);
+				contentView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
+				bigView.setImageViewResource(R.id.notification_image, R.drawable.unknown_album);
+			}
 
-        contentView.setTextViewText(R.id.trackname, title);
-        bigView.setTextViewText(R.id.trackname, title);
-        contentView.setTextViewText(R.id.artist, text);
-        bigView.setTextViewText(R.id.artist, text);
-        contentView.setTextViewText(R.id.album, album);
-        bigView.setTextViewText(R.id.album, album);
 
-		boolean useFiveStarRating = KoinJavaComponent.get(FeatureStorage.class).isFeatureEnabled(Feature.FIVE_STAR_RATING);
-		if (!useFiveStarRating)	bigView.setViewVisibility(R.id.notification_rating, View.INVISIBLE);
-		else
-		{
-			bigView.setImageViewResource(R.id.notification_five_star_1, rating > 0 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
-			bigView.setImageViewResource(R.id.notification_five_star_2, rating > 1 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
-			bigView.setImageViewResource(R.id.notification_five_star_3, rating > 2 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
-			bigView.setImageViewResource(R.id.notification_five_star_4, rating > 3 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
-			bigView.setImageViewResource(R.id.notification_five_star_5, rating > 4 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
+			contentView.setTextViewText(R.id.trackname, title);
+			bigView.setTextViewText(R.id.trackname, title);
+			contentView.setTextViewText(R.id.artist, text);
+			bigView.setTextViewText(R.id.artist, text);
+			contentView.setTextViewText(R.id.album, album);
+			bigView.setTextViewText(R.id.album, album);
+
+			boolean useFiveStarRating = KoinJavaComponent.get(FeatureStorage.class).isFeatureEnabled(Feature.FIVE_STAR_RATING);
+			if (!useFiveStarRating)
+				bigView.setViewVisibility(R.id.notification_rating, View.INVISIBLE);
+			else {
+				bigView.setImageViewResource(R.id.notification_five_star_1, rating > 0 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
+				bigView.setImageViewResource(R.id.notification_five_star_2, rating > 1 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
+				bigView.setImageViewResource(R.id.notification_five_star_3, rating > 2 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
+				bigView.setImageViewResource(R.id.notification_five_star_4, rating > 3 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
+				bigView.setImageViewResource(R.id.notification_five_star_5, rating > 4 ? R.drawable.ic_star_full_dark : R.drawable.ic_star_hollow_dark);
+			}
 		}
 
         Notification notification = notificationBuilder.build();

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceImpl.java
@@ -752,6 +752,7 @@ public class DownloadServiceImpl extends Service implements DownloadService
 			if (tabInstance != null)
 			{
 				stopForeground(true);
+				clearRemoteControl();
 				isInForeground = false;
 				tabInstance.hideNowPlaying();
 			}
@@ -1277,6 +1278,7 @@ public class DownloadServiceImpl extends Service implements DownloadService
 			if (tabInstance != null)
 			{
 				stopForeground(true);
+				clearRemoteControl();
 				isInForeground = false;
 				tabInstance.hideNowPlaying();
 			}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceLifecycleSupport.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/DownloadServiceLifecycleSupport.java
@@ -289,6 +289,7 @@ public class DownloadServiceLifecycleSupport
 			return;
 		}
 		Log.i(TAG, "Deserialized currentPlayingIndex: " + state.currentPlayingIndex + ", currentPlayingPosition: " + state.currentPlayingPosition);
+		// TODO: here the autoPlay = false creates problems when Ultrasonic is started by a Play MediaButton as the player won't start this way.
 		downloadService.restore(state.songs, state.currentPlayingIndex, state.currentPlayingPosition, false, false);
 
 		// Work-around: Serialize again, as the restore() method creates a serialization without current playing info.
@@ -321,7 +322,11 @@ public class DownloadServiceLifecycleSupport
 				downloadService.stop();
 				break;
 			case KeyEvent.KEYCODE_MEDIA_PLAY:
-				if (downloadService.getPlayerState() != PlayerState.STARTED)
+				if (downloadService.getPlayerState() == PlayerState.IDLE)
+				{
+					downloadService.play();
+				}
+				else if (downloadService.getPlayerState() != PlayerState.STARTED)
 				{
 					downloadService.start();
 				}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Constants.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Constants.java
@@ -132,6 +132,7 @@ public final class Constants
 	public static final String PREFERENCES_KEY_IMAGE_LOADER_CONCURRENCY = "imageLoaderConcurrency";
 	public static final String PREFERENCES_KEY_FF_IMAGE_LOADER = "ff_new_image_loader";
 	public static final String PREFERENCES_KEY_USE_FIVE_STAR_RATING = "use_five_star_rating";
+	public static final String PREFERENCES_KEY_CATEGORY_NOTIFICATIONS = "notificationsCategory";
 
 	// Number of free trial days for non-licensed servers.
 	public static final int FREE_TRIAL_DAYS = 30;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -36,6 +36,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.net.wifi.WifiManager;
+import android.os.Build;
 import android.os.Environment;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
@@ -155,12 +156,16 @@ public class Util extends DownloadActivity
 
 	public static boolean isNotificationEnabled(Context context)
 	{
+		// After API26 foreground services must be used for music playback, and they must have a notification
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) return true;
 		SharedPreferences preferences = getPreferences(context);
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_NOTIFICATION, false);
 	}
 
 	public static boolean isNotificationAlwaysEnabled(Context context)
 	{
+		// After API26 foreground services must be used for music playback, and they must have a notification
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) return true;
 		SharedPreferences preferences = getPreferences(context);
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_ALWAYS_SHOW_NOTIFICATION, false);
 	}

--- a/ultrasonic/src/main/res/xml/settings.xml
+++ b/ultrasonic/src/main/res/xml/settings.xml
@@ -107,7 +107,9 @@
             a:summary="@string/settings.playback.resume_play_on_headphones_plug.summary"
             />
     </PreferenceCategory>
-    <PreferenceCategory a:title="@string/settings.notifications_title">
+    <PreferenceCategory
+        a:title="@string/settings.notifications_title"
+        a:key="notificationsCategory">
         <CheckBoxPreference
             a:defaultValue="true"
             a:key="showNowPlaying"


### PR DESCRIPTION
This completes the API28 upgrade.

It contains some notification related changes, some background service related changes and other fixes. I've tested it on everything I could and it seems to be stable.

As you see there were some problems with the background services:
- Google says that background services may be killed when the app is in background, and also they can't be started when the app is in the background as the start will throw an exception.
- Google suggests to use foreground services with startForegroundService, however, foreground services **must** call the startForeground with a notification in ~5 seconds.
- Ultrasonic doesn't do that, it only displays a notification when it is playing. The DownloadServiceImpl usually just hangs around in the background always.
- This created exceptions on API26-27 devices (startForeground wasn't called in time) and Ultrasonic was killed. Interestingly, this exception doesn't happed on API28+ (maybe Google noticed that everybody has problems with that approach, I'm not sure, didn't find anything related in the docs).

The current solution to this is that the DownloadServiceImpl is still started as a background service.
- When Ultrasonic is playing in the background, everything just magically works, as long as it has the notification displayed.
- As mentioned above, when Ultrasonic is idling in the background, the service may be stopped. No problem, it will be restarted next time when Ultrasonic comes to foreground.
- Starting the service when in the background will throw an exception, which results in that DownloadServiceImpl instance will be temporarily null.
  - this is not a problem as it is usually started from the UI which isn't possible anyways when Ultrasonic is in the background
  - it only affects the media buttons (e.g. headset), I added a temporary workaround for that.

Known problems:
The media buttons will start the DownloadServiceImpl even when the app is in the background, and the playlist is empty. In this case Ultrasonic won't start playing, the notification won't be displayed, and on API26-27 devices the app will be killed.

IMHO the real solution to this background service problem would be to refactor the DownloadServiceImpl to use a separate service for playback. This new service should be a foreground service, with an always visible notification when it plays. Other parts of the DownloadServiceImpl shouldn't be a service at all.

Penny for your thoughts.