### PR TITLE
Fixed Jukebox start bug

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/JukeboxMediaPlayer.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/JukeboxMediaPlayer.java
@@ -319,8 +319,9 @@ public class JukeboxMediaPlayer
 
 	public void setEnabled(boolean enabled)
 	{
-		tasks.clear();
+		this.enabled = enabled;
 
+		tasks.clear();
 		if (enabled)
 		{
 			updatePlaylist();


### PR DESCRIPTION
This fixes #296 (at least I hope, as the description for that is not entirely clear)

There was a bug in the JukeboxMediaPlayer which prevented it to be enabled.
With this fix it seems to work as intended. 
Tested with Subsonic v6.1.6.