### PR TITLE
Fixed missing Genre Refresh functionality

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectGenreActivity.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SelectGenreActivity.java
@@ -111,13 +111,14 @@ public class SelectGenreActivity extends SubsonicTabActivity implements AdapterV
 			@Override
 			protected List<Genre> doInBackground() throws Throwable
 			{
+				boolean refresh = getIntent().getBooleanExtra(Constants.INTENT_EXTRA_NAME_REFRESH, false);
 				MusicService musicService = MusicServiceFactory.getMusicService(SelectGenreActivity.this);
 
 				List<Genre> genres = new ArrayList<Genre>();
 
 				try
 				{
-					genres = musicService.getGenres(SelectGenreActivity.this, this);
+					genres = musicService.getGenres(refresh, SelectGenreActivity.this, this);
 				}
 				catch (Exception x)
 				{

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
@@ -405,14 +405,18 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public List<Genre> getGenres(Context context, ProgressListener progressListener) throws Exception
+	public List<Genre> getGenres(boolean refresh, Context context, ProgressListener progressListener) throws Exception
 	{
 		checkSettingsChanged(context);
+		if (refresh)
+		{
+			cachedGenres.clear();
+		}
 		List<Genre> result = cachedGenres.get();
 
 		if (result == null)
 		{
-			result = musicService.getGenres(context, progressListener);
+			result = musicService.getGenres(refresh, context, progressListener);
 			cachedGenres.set(result);
 		}
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MusicService.java
@@ -53,7 +53,7 @@ public interface MusicService
 
 	boolean isLicenseValid(Context context, ProgressListener progressListener) throws Exception;
 
-	List<Genre> getGenres(Context context, ProgressListener progressListener) throws Exception;
+	List<Genre> getGenres(boolean refresh, Context context, ProgressListener progressListener) throws Exception;
 
 	void star(String id, String albumId, String artistId, Context context, ProgressListener progressListener) throws Exception;
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/OfflineMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/OfflineMusicService.java
@@ -770,7 +770,7 @@ public class OfflineMusicService extends RESTMusicService
 	}
 
 	@Override
-	public List<Genre> getGenres(Context context, ProgressListener progressListener) throws Exception
+	public List<Genre> getGenres(boolean refresh, Context context, ProgressListener progressListener) throws Exception
 	{
 		throw new OfflineException("Getting Genres not available in offline mode");
 	}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/RESTMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/RESTMusicService.java
@@ -829,7 +829,7 @@ public class RESTMusicService implements MusicService {
     }
 
     @Override
-    public List<Genre> getGenres(Context context,
+    public List<Genre> getGenres(boolean refresh, Context context,
                                  ProgressListener progressListener) throws Exception {
         updateProgressListener(progressListener, R.string.parser_reading);
         Response<GenresResponse> response = subsonicAPIClient.getApi().getGenres().execute();


### PR DESCRIPTION
Fixes #221 .
This is a straightforward fix; the refresh functionality was missing from the Genres Activity, the genres were always read up from the cache. Added a "refresh" flag like in the other similar Activities.