### PR TITLE
Fixed issues with new Server Settings

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/EditServerActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/EditServerActivity.kt
@@ -13,6 +13,7 @@ import com.google.android.material.textfield.TextInputLayout
 import java.io.IOException
 import java.net.MalformedURLException
 import java.net.URL
+import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
 import org.moire.ultrasonic.BuildConfig
 import org.moire.ultrasonic.R
@@ -20,7 +21,9 @@ import org.moire.ultrasonic.api.subsonic.SubsonicAPIClient
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIVersions
 import org.moire.ultrasonic.api.subsonic.SubsonicClientConfiguration
 import org.moire.ultrasonic.api.subsonic.response.SubsonicResponse
+import org.moire.ultrasonic.data.ActiveServerProvider
 import org.moire.ultrasonic.data.ServerSetting
+import org.moire.ultrasonic.service.MusicServiceFactory
 import org.moire.ultrasonic.service.SubsonicRESTException
 import org.moire.ultrasonic.util.Constants
 import org.moire.ultrasonic.util.ErrorDialog
@@ -41,6 +44,8 @@ internal class EditServerActivity : AppCompatActivity() {
     }
 
     private val serverSettingsModel: ServerSettingsModel by viewModel()
+    private val activeServerProvider: ActiveServerProvider by inject()
+
     private var currentServerSetting: ServerSetting? = null
 
     private var serverNameEditText: TextInputLayout? = null
@@ -90,6 +95,13 @@ internal class EditServerActivity : AppCompatActivity() {
                 if (currentServerSetting != null) {
                     if (getFields()) {
                         serverSettingsModel.updateItem(currentServerSetting)
+                        // Apply modifications if the current server was modified
+                        if (
+                            activeServerProvider.getActiveServer().id ==
+                            currentServerSetting!!.id
+                        ) {
+                            MusicServiceFactory.resetMusicService()
+                        }
                         finish()
                     }
                 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/ServerRowAdapter.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/ServerRowAdapter.kt
@@ -53,7 +53,7 @@ internal class ServerRowAdapter(
     }
 
     override fun getCount(): Int {
-        return if (manageMode) data.size - 1 else data.size
+        return if (manageMode) data.size else data.size + 1
     }
 
     override fun getItem(position: Int): Any {
@@ -81,8 +81,13 @@ internal class ServerRowAdapter(
         val image = vi?.findViewById<ImageView>(R.id.server_image)
         val serverMenu = vi?.findViewById<ImageButton>(R.id.server_menu)
 
-        text?.text = data.single { setting -> setting.index == index }.name
-        description?.text = data.single { setting -> setting.index == index }.url
+        if (index == 0) {
+            text?.text = context.getString(R.string.main_offline)
+            description?.text = ""
+        } else {
+            text?.text = data.singleOrNull { setting -> setting.index == index }?.name ?: ""
+            description?.text = data.singleOrNull { setting -> setting.index == index }?.url ?: ""
+        }
 
         // Provide icons for the row
         if (index == 0) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/ServerRowAdapter.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/ServerRowAdapter.kt
@@ -85,8 +85,10 @@ internal class ServerRowAdapter(
             text?.text = context.getString(R.string.main_offline)
             description?.text = ""
         } else {
-            text?.text = data.singleOrNull { setting -> setting.index == index }?.name ?: ""
-            description?.text = data.singleOrNull { setting -> setting.index == index }?.url ?: ""
+            val setting = data.singleOrNull { t -> t.index == index }
+            text?.text = setting?.name ?: ""
+            description?.text = setting?.url ?: ""
+            if (setting == null) serverMenu?.visibility = View.INVISIBLE
         }
 
         // Provide icons for the row

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/ServerSelectorActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/ServerSelectorActivity.kt
@@ -144,8 +144,9 @@ internal class ServerSelectorActivity : AppCompatActivity() {
                 if (activeServerProvider.getActiveServer().index != index) {
                     service.clearIncomplete()
                     activeServerProvider.setActiveServerByIndex(index)
+                    service.isJukeboxEnabled =
+                        activeServerProvider.getActiveServer().jukeboxByDefault
                 }
-                service.isJukeboxEnabled = activeServerProvider.getActiveServer().jukeboxByDefault
             }
         }
         Log.i(TAG, "Active server was set to: $index")

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
@@ -75,7 +75,7 @@ class ActiveServerProvider(
         }
 
         GlobalScope.launch(Dispatchers.IO) {
-            val serverId = repository.findByIndex(index)!!.id
+            val serverId = repository.findByIndex(index)?.id ?: 0
             setActiveServerId(context, serverId)
         }
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSettingDao.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSettingDao.kt
@@ -54,4 +54,10 @@ interface ServerSettingDao {
      */
     @Query("SELECT COUNT(*) FROM serverSetting")
     suspend fun count(): Int?
+
+    /**
+     * Retrieves the greatest value of the Id column in the table
+     */
+    @Query("SELECT MAX([id]) FROM serverSetting")
+    suspend fun getMaxId(): Int?
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSettingDao.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSettingDao.kt
@@ -1,5 +1,6 @@
 package org.moire.ultrasonic.data
 
+import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
@@ -35,7 +36,7 @@ interface ServerSettingDao {
      * Loads all Server Settings from the table
      */
     @Query("SELECT * FROM serverSetting")
-    suspend fun loadAllServerSettings(): Array<ServerSetting>
+    fun loadAllServerSettings(): LiveData<List<ServerSetting>>
 
     /**
      * Finds a Server Setting by its unique Id
@@ -50,6 +51,13 @@ interface ServerSettingDao {
     suspend fun findByIndex(index: Int): ServerSetting?
 
     /**
+     * Finds a Server Setting by its Index in the Select List
+     * @return LiveData of the ServerSetting
+     */
+    @Query("SELECT * FROM serverSetting WHERE [index] = :index")
+    fun getLiveServerSettingByIndex(index: Int): LiveData<ServerSetting?>
+
+    /**
      * Retrieves the count of rows in the table
      */
     @Query("SELECT COUNT(*) FROM serverSetting")
@@ -60,4 +68,10 @@ interface ServerSettingDao {
      */
     @Query("SELECT MAX([id]) FROM serverSetting")
     suspend fun getMaxId(): Int?
+
+    /**
+     * Retrieves the greatest value of the Index column in the table
+     */
+    @Query("SELECT MAX([index]) FROM serverSetting")
+    suspend fun getMaxIndex(): Int?
 }


### PR DESCRIPTION
Fixes #307 .
Contains the following changes:
- Fixed Server Id handling
- Made Server Indexing more robust, so in case of an error Ultrasonic won't freeze and can try to recover
- I'm such a noob, just noticed that Room can handle LiveData by itself. Redesigned ServerSettingsModel
- Added a flag to old Server Preferences which signals migration, this way when all servers are deleted, Ultrasonic won't try to migrate again
- Fixed some issues when the currently active server was edited or selected again
