### PR TITLE
Fix fatal error loading unknown album cover

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/LegacyImageLoader.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/LegacyImageLoader.java
@@ -120,11 +120,11 @@ public class LegacyImageLoader implements Runnable, ImageLoader {
     }
 
     private void createLargeUnknownImage(Context context) {
-        BitmapDrawable drawable = (BitmapDrawable) context.getResources().getDrawable(R.drawable.unknown_album);
+        Drawable drawable = context.getResources().getDrawable(R.drawable.unknown_album);
         Log.i(TAG, "createLargeUnknownImage");
 
         if (drawable != null) {
-            largeUnknownImage = Util.scaleBitmap(drawable.getBitmap(), imageSizeLarge);
+            largeUnknownImage = Util.createBitmapFromDrawable(drawable);
         }
     }
 


### PR DESCRIPTION
Fix:

```
E/AndroidRuntime: FATAL EXCEPTION: Thread-5
    Process: org.moire.ultrasonic.debug, PID: 11159
    java.lang.ClassCastException: android.graphics.drawable.VectorDrawable cannot be cast to android.graphics.drawable.BitmapDrawable
        at org.moire.ultrasonic.util.LegacyImageLoader.createLargeUnknownImage(LegacyImageLoader.java:123)
        at org.moire.ultrasonic.util.LegacyImageLoader.<init>(LegacyImageLoader.java:83)
        at org.moire.ultrasonic.activity.SubsonicTabActivity.getImageLoader(SubsonicTabActivity.java:799)
        at org.moire.ultrasonic.util.FileUtil.getAlbumArtBitmap(FileUtil.java:220)
        at org.moire.ultrasonic.service.LocalMediaPlayer.updateRemoteControl(LocalMediaPlayer.java:492)
        at org.moire.ultrasonic.service.LocalMediaPlayer.setCurrentPlaying(LocalMediaPlayer.java:329)
        at org.moire.ultrasonic.service.MediaPlayerService.setCurrentPlaying(MediaPlayerService.java:250)
        at org.moire.ultrasonic.service.MediaPlayerService.play(MediaPlayerService.java:394)
        at org.moire.ultrasonic.service.MediaPlayerControllerImpl$2.accept(MediaPlayerControllerImpl.java:125)
        at org.moire.ultrasonic.service.MediaPlayerControllerImpl$2.accept(MediaPlayerControllerImpl.java:122)
        at org.moire.ultrasonic.service.MediaPlayerService$1.run(MediaPlayerService.java:122)
```

Signed-off-by: Óscar García Amor <ogarcia@connectical.com>