### PR TITLE
Fix gradle out of memory error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2g
 
 kotlin.incremental=true
 kotlin.caching.enabled=true


### PR DESCRIPTION
I'm really a gradle noob, so this may not be the way...
The assembleRelease failed with OutOfMemoryException, and everybody suggests that the solution is to give more memory to the Jvm.
I'm not sure this will work, I can't reproduce it on my machine. For me, assembleRelease sometimes runs, sometimes fails, currently it runs after adding this line and it don't want to fail... yet.
