### PR TITLE
Fixed Opus file handling and offline file name bug

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/FileUtil.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/FileUtil.java
@@ -51,7 +51,7 @@ public class FileUtil
 	private static final String TAG = FileUtil.class.getSimpleName();
 	private static final String[] FILE_SYSTEM_UNSAFE = {"/", "\\", "..", ":", "\"", "?", "*", "<", ">", "|"};
 	private static final String[] FILE_SYSTEM_UNSAFE_DIR = {"\\", "..", ":", "\"", "?", "*", "<", ">", "|"};
-	private static final List<String> MUSIC_FILE_EXTENSIONS = Arrays.asList("mp3", "ogg", "aac", "flac", "m4a", "wav", "wma");
+	private static final List<String> MUSIC_FILE_EXTENSIONS = Arrays.asList("mp3", "ogg", "aac", "flac", "m4a", "wav", "wma", "opus");
 	private static final List<String> VIDEO_FILE_EXTENSIONS = Arrays.asList("flv", "mp4", "m4v", "wmv", "avi", "mov", "mpg", "mkv");
 	private static final List<String> PLAYLIST_FILE_EXTENSIONS = Collections.singletonList("m3u");
 	private static final Pattern TITLE_WITH_TRACK = Pattern.compile("^\\d\\d-.*");
@@ -60,10 +60,19 @@ public class FileUtil
 	{
 		File dir = getAlbumDirectory(context, song);
 
+		// If the song already exists, it isn't necessary to give it a name
+		if (!TextUtils.isEmpty(song.getPath()))
+		{
+			File songFile = new File(String.format("%s/%s", getMusicDirectory(context).getPath(), fileSystemSafeDir(song.getPath())));
+			if (songFile.exists() && songFile.isFile()) return songFile;
+		}
+
+		// Generate a file name for the song
 		StringBuilder fileName = new StringBuilder(256);
 		Integer track = song.getTrack();
 
-		if (!TITLE_WITH_TRACK.matcher(song.getTitle()).matches()) {//check if filename already had track number
+		//check if filename already had track number
+		if (!TITLE_WITH_TRACK.matcher(song.getTitle()).matches()) {
 			if (track != null) {
 				if (track < 10) {
 					fileName.append('0');

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/FileUtil.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/FileUtil.java
@@ -60,11 +60,10 @@ public class FileUtil
 	{
 		File dir = getAlbumDirectory(context, song);
 
-		// If the song already exists, it isn't necessary to give it a name
-		if (!TextUtils.isEmpty(song.getPath()))
+		// Do not generate new name for offline files. Offline files will have their Path as their Id.
+		if (!TextUtils.isEmpty(song.getId()))
 		{
-			File songFile = new File(String.format("%s/%s", getMusicDirectory(context).getPath(), fileSystemSafeDir(song.getPath())));
-			if (songFile.exists() && songFile.isFile()) return songFile;
+			if (song.getId().startsWith(dir.getAbsolutePath())) return new File(song.getId());
 		}
 
 		// Generate a file name for the song


### PR DESCRIPTION
Fixes #227 
- This is a straightforward fix, "opus" extension was missing from the list of audio file extensions which Ultrasonic recognizes.

Fixes #328
- Checks if the file in the "Path" property already exists, and won't rename it if it does.