### PR TITLE
Fixed removed constructor by minify in genres API

### DIFF
--- a/ultrasonic/minify/proguard-main.pro
+++ b/ultrasonic/minify/proguard-main.pro
@@ -2,3 +2,4 @@
 
 ### Don't remove subsonic api serializers/entities
 -keep class org.moire.ultrasonic.api.subsonic.response.** { *; }
+-keep class org.moire.ultrasonic.api.subsonic.models.** { *; }


### PR DESCRIPTION
Fixes #240 
The problem was absolutely as @Tapchicoma wrote, minify removed a constructor which it thought useless, but it was needed for json deserialization.
Added all the models from the folder to -keep so this won't happen again.

@ogarcia would you please check if this solution works for you too? I don't have supysonic and I tested it only with SoapUi.