### PR TITLE
Fixed clearing the playlist when MediaPlayerService isn't running

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
@@ -361,7 +361,16 @@ public class MediaPlayerControllerImpl implements MediaPlayerController
 	public synchronized void clear(boolean serialize)
 	{
 		MediaPlayerService mediaPlayerService = MediaPlayerService.getRunningInstance();
-		if (mediaPlayerService != null)	mediaPlayerService.clear(serialize);
+		if (mediaPlayerService != null) {
+			mediaPlayerService.clear(serialize);
+		} else {
+			// If no MediaPlayerService is available, just empty the playlist
+			downloader.clear();
+			if (serialize) {
+				downloadQueueSerializer.serializeDownloadQueue(downloader.downloadList,
+					downloader.getCurrentPlayingIndex(), getPlayerPosition());
+			}
+		}
 
 		jukeboxMediaPlayer.getValue().updatePlaylist();
 	}


### PR DESCRIPTION
Fixes #323 

This is a simple fix. Clear() was returning without doing anything if there was no MediaPlayerService available (e.g. the player was stopped). There are other similar functions which operate on the playlist without a MediaPlayerService, so Clear() was modified to access the playlist directly similar to those.