### PR TITLE
Fixed too small icons and margins

### DIFF
--- a/ultrasonic/src/main/res/layout/album_buttons.xml
+++ b/ultrasonic/src/main/res/layout/album_buttons.xml
@@ -9,7 +9,8 @@
     <ImageView
         android:id="@+id/select_album_select"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/select_all"
         android:visibility="gone" />
@@ -17,7 +18,8 @@
     <ImageView
         android:id="@+id/select_album_play_now"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/media_play"
         android:visibility="gone" />
@@ -25,7 +27,8 @@
     <ImageView
         android:id="@+id/select_album_play_next"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/media_play_next"
         android:visibility="gone" />    
@@ -33,7 +36,8 @@
     <ImageView
         android:id="@+id/select_album_play_last"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/add_to_queue"
         android:visibility="gone" />
@@ -41,7 +45,8 @@
     <ImageView
         android:id="@+id/select_album_pin"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/pin"
         android:visibility="gone" />
@@ -49,7 +54,8 @@
     <ImageView
         android:id="@+id/select_album_unpin"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/unpin"
         android:visibility="gone" />
@@ -57,7 +63,8 @@
     <ImageView
         android:id="@+id/select_album_download"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/download"
         android:visibility="gone" />    
@@ -65,7 +72,8 @@
     <ImageView
         android:id="@+id/select_album_delete"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/stop"
         android:visibility="gone" />
@@ -73,7 +81,8 @@
     <ImageView
         android:id="@+id/select_album_more"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="32dp"
+        android:scaleType="fitCenter"
         android:layout_weight="1"
         android:src="?attr/forward"
         android:visibility="gone" />

--- a/ultrasonic/src/main/res/layout/appwidget4x1.xml
+++ b/ultrasonic/src/main/res/layout/appwidget4x1.xml
@@ -79,7 +79,7 @@
                 a:layout_height="fill_parent"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"               
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_backward_normal_dark" />
 
             <ImageButton
@@ -88,7 +88,7 @@
                 a:layout_height="fill_parent"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"              
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_start_normal_dark" />
 
             <ImageButton
@@ -97,7 +97,7 @@
                 a:layout_height="fill_parent"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_forward_normal_dark" />
         </LinearLayout>
     </LinearLayout>

--- a/ultrasonic/src/main/res/layout/appwidget4x2.xml
+++ b/ultrasonic/src/main/res/layout/appwidget4x2.xml
@@ -97,28 +97,28 @@
             <ImageButton
                 a:id="@+id/control_previous"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"               
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_backward_normal_dark" />
 
             <ImageButton
                 a:id="@+id/control_play"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"              
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_start_normal_dark" />
 
             <ImageButton
                 a:id="@+id/control_next"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_forward_normal_dark" />
         </LinearLayout>
     </LinearLayout>

--- a/ultrasonic/src/main/res/layout/appwidget4x3.xml
+++ b/ultrasonic/src/main/res/layout/appwidget4x3.xml
@@ -82,28 +82,28 @@
             <ImageButton
                 a:id="@+id/control_previous"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_backward_normal_dark" />
 
             <ImageButton
                 a:id="@+id/control_play"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_start_normal_dark" />
 
             <ImageButton
                 a:id="@+id/control_next"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_forward_normal_dark" />
         </LinearLayout>
 

--- a/ultrasonic/src/main/res/layout/appwidget4x4.xml
+++ b/ultrasonic/src/main/res/layout/appwidget4x4.xml
@@ -83,28 +83,28 @@
             <ImageButton
                 a:id="@+id/control_previous"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_backward_normal_dark" />
 
             <ImageButton
                 a:id="@+id/control_play"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_start_normal_dark" />
 
             <ImageButton
                 a:id="@+id/control_next"
                 a:layout_width="0dip"
-                a:layout_height="wrap_content"
+                a:layout_height="32dp"
                 a:layout_weight="1"
                 a:background="@color/transparent"
-                a:scaleType="center"
+                a:scaleType="fitCenter"
                 a:src="@drawable/media_forward_normal_dark" />
         </LinearLayout>
 

--- a/ultrasonic/src/main/res/layout/media_buttons.xml
+++ b/ultrasonic/src/main/res/layout/media_buttons.xml
@@ -9,20 +9,24 @@
               a:paddingRight="4dip"
     >
 
-<ImageView
+    <ImageView
         a:id="@+id/download_shuffle"
         a:layout_width="0dip"
-        a:layout_height="wrap_content"
+        a:layout_height="32dp"
+        a:layout_gravity="center"
         a:layout_weight="1"
         a:focusable="true"
-        a:src="?attr/media_shuffle"
         a:paddingLeft="2dip"
-        a:paddingRight="8dip"/>
+        a:paddingRight="8dip"
+        a:scaleType="fitCenter"
+        a:src="?attr/media_shuffle" />
 
     <org.moire.ultrasonic.view.AutoRepeatButton
         a:id="@+id/download_previous"
         a:layout_width="0dip"
-        a:layout_height="wrap_content"
+        a:layout_height="48dp"
+        a:scaleType="fitCenter"
+        a:layout_gravity="center"
         a:layout_weight="1"
         a:focusable="true"
         a:src="?attr/media_previous"
@@ -32,7 +36,8 @@
     <ImageView
         a:id="@+id/download_start"
         a:layout_width="0dip"
-        a:layout_height="wrap_content"
+        a:layout_height="56dp"
+        a:scaleType="fitCenter"
         a:layout_weight="1"
         a:focusable="true"
         a:src="?attr/media_play"
@@ -42,7 +47,8 @@
     <ImageView
         a:id="@+id/download_pause"
         a:layout_width="0dip"
-        a:layout_height="wrap_content"
+        a:layout_height="56dp"
+        a:scaleType="fitCenter"
         a:layout_weight="1"
         a:focusable="true"
         a:src="?attr/media_pause"
@@ -52,7 +58,8 @@
     <ImageView
         a:id="@+id/download_stop"
         a:layout_width="0dip"
-        a:layout_height="wrap_content"
+        a:layout_height="56dp"
+        a:scaleType="fitCenter"
         a:layout_weight="1"
         a:focusable="true"
         a:src="?attr/media_stop"
@@ -62,7 +69,9 @@
     <org.moire.ultrasonic.view.AutoRepeatButton
         a:id="@+id/download_next"
         a:layout_width="0dip"
-        a:layout_height="wrap_content"
+        a:layout_height="48dp"
+        a:scaleType="fitCenter"
+        a:layout_gravity="center"
         a:layout_weight="1"
         a:focusable="true"
         a:src="?attr/media_next"
@@ -72,7 +81,9 @@
     <ImageView
         a:id="@+id/download_repeat"
         a:layout_width="0dip"
-        a:layout_height="wrap_content"
+        a:layout_height="32dp"
+        a:scaleType="fitCenter"
+        a:layout_gravity="center"
         a:layout_weight="1"
         a:focusable="true"
         a:src="?attr/media_repeat_off"

--- a/ultrasonic/src/main/res/layout/notification.xml
+++ b/ultrasonic/src/main/res/layout/notification.xml
@@ -70,48 +70,52 @@
         android:layout_gravity="center"
         android:gravity="end"
         android:orientation="horizontal"
-        android:paddingRight="4dp">
+        android:paddingRight="8dp">
 
         <ImageButton
             android:id="@+id/control_previous"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
             android:layout_gravity="center"
             android:layout_weight="1"
             android:background="@drawable/btn_bg"
             android:scaleType="fitXY"
+            android:layout_margin="2dp"
             android:src="@drawable/media_backward_normal_dark" />
 
         <ImageButton
             android:id="@+id/control_play"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
             android:layout_gravity="center"
             android:layout_weight="1"
             android:background="@drawable/btn_bg"
             android:scaleType="fitXY"
+            android:layout_margin="2dp"
             android:src="@drawable/media_pause_normal_dark" />
 
         <ImageButton
             android:id="@+id/control_next"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
             android:layout_gravity="center"
             android:layout_weight="1"
             android:background="@drawable/btn_bg"
             android:scaleType="fitXY"
+            android:layout_margin="2dp"
             android:src="@drawable/media_forward_normal_dark" />
 
         <ImageButton
             android:id="@+id/control_stop"
-            android:layout_width="32dip"
-            android:layout_height="32dip"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
             android:layout_gravity="center"
-            android:layout_marginLeft="4dp"
             android:alpha="70"
             android:background="@drawable/btn_bg"
             android:scaleType="fitXY"
-            android:src="@drawable/ic_menu_close_dark" />
+            android:src="@drawable/ic_menu_close_dark"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp" />
     </LinearLayout>
 
 </LinearLayout>

--- a/ultrasonic/src/main/res/layout/notification_large.xml
+++ b/ultrasonic/src/main/res/layout/notification_large.xml
@@ -157,8 +157,9 @@
 
             <ImageButton
                 android:id="@+id/control_previous"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:scaleType="fitCenter"
                 android:layout_gravity="center"
                 android:layout_weight="1"
                 android:background="@drawable/btn_bg"
@@ -166,8 +167,9 @@
 
             <ImageButton
                 android:id="@+id/control_play"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:scaleType="fitCenter"
                 android:layout_gravity="center"
                 android:layout_weight="1"
                 android:background="@drawable/btn_bg"
@@ -175,8 +177,9 @@
 
             <ImageButton
                 android:id="@+id/control_next"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:scaleType="fitCenter"
                 android:layout_gravity="center"
                 android:layout_weight="1"
                 android:background="@drawable/btn_bg"

--- a/ultrasonic/src/main/res/layout/now_playing.xml
+++ b/ultrasonic/src/main/res/layout/now_playing.xml
@@ -54,13 +54,14 @@
 
         <ImageView
             android:id="@+id/now_playing_control_play"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
             android:layout_gravity="center|right"
             android:layout_marginTop="2dip"
-            android:layout_marginRight="5dip"
+            android:layout_marginRight="16dip"
             android:layout_weight="0.0"
             android:focusable="false"
+            android:scaleType="fitCenter"
             android:src="?attr/media_pause" />
 
     </LinearLayout>

--- a/ultrasonic/src/main/res/layout/song_list_item.xml
+++ b/ultrasonic/src/main/res/layout/song_list_item.xml
@@ -93,7 +93,8 @@
         a:background="@android:color/transparent"
         a:focusable="false"
         a:gravity="center_vertical"
-        a:paddingRight="8dip"
-        a:src="?attr/drag_queue" />
+        a:layout_marginRight="16dip"
+        a:src="?attr/drag_queue"
+        a:layout_marginEnd="16dip" />
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #344 , fixes #342 

- Changed icon sizes from the default 24dp to 32dp in widgets, album_buttons, small and large notifications and mini now playing.
- Added margins in now playing and song list items (the drag icon was too close to the scroll bar)
- Made the media buttons larger, the play/pause/stop is the largest. Now it is similar to how spotify looks. It looks a bit funny now, I'm not sure if I should just get used to it, or now it's too large. What do you think, @ogarcia ?

Tested it on some screen resolutions, generally it looks good.