### PR TITLE
Implemented single button play/pause support for old Bluetooth devices

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
@@ -190,7 +190,17 @@ public class MediaPlayerLifecycleSupport
 			return;
 		}
 
-		final int keyCode = event.getKeyCode();
+		final int keyCode;
+		int receivedKeyCode = event.getKeyCode();
+		// Translate PLAY and PAUSE codes to PLAY_PAUSE to improve compatibility with old Bluetooth devices
+		if (Util.getSingleButtonPlayPause(context) &&
+			(receivedKeyCode == KeyEvent.KEYCODE_MEDIA_PLAY ||
+				receivedKeyCode == KeyEvent.KEYCODE_MEDIA_PAUSE)) {
+			Timber.i("Single button Play/Pause is set, rewriting keyCode to PLAY_PAUSE");
+			keyCode = KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
+		}
+		else keyCode = receivedKeyCode;
+
 		boolean autoStart = (keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE ||
 				keyCode == KeyEvent.KEYCODE_MEDIA_PLAY ||
 				keyCode == KeyEvent.KEYCODE_HEADSETHOOK ||

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Constants.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Constants.java
@@ -137,6 +137,7 @@ public final class Constants
 	public static final String PREFERENCES_KEY_FIRST_RUN_EXECUTED = "firstRunExecuted";
 	public static final String PREFERENCES_KEY_RESUME_ON_BLUETOOTH_DEVICE = "resumeOnBluetoothDevice";
 	public static final String PREFERENCES_KEY_PAUSE_ON_BLUETOOTH_DEVICE = "pauseOnBluetoothDevice";
+	public static final String PREFERENCES_KEY_SINGLE_BUTTON_PLAY_PAUSE = "singleButtonPlayPause";
 	public static final String PREFERENCES_KEY_DEBUG_LOG_TO_FILE = "debugLogToFile";
 
 	public static final int PREFERENCE_VALUE_ALL = 0;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -1221,6 +1221,12 @@ public class Util
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_CLEAR_BOOKMARK, false);
 	}
 
+	public static boolean getSingleButtonPlayPause(Context context)
+	{
+		SharedPreferences preferences = getPreferences(context);
+		return preferences.getBoolean(Constants.PREFERENCES_KEY_SINGLE_BUTTON_PLAY_PAUSE, false);
+	}
+
 	public static String formatTotalDuration(long totalDuration, boolean inMilliseconds)
 	{
 		long millis = totalDuration;

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -407,6 +407,8 @@
     <string name="settings.playback.bluetooth_all">All Bluetooth devices</string>
     <string name="settings.playback.bluetooth_a2dp">Only audio (A2DP) devices</string>
     <string name="settings.playback.bluetooth_disabled">Disabled</string>
+    <string name="settings.playback.single_button_bluetooth_device">Single button Play/Pause on Bluetooth device</string>
+    <string name="settings.playback.single_button_bluetooth_device_summary">Enabling this may help with older Bluetooth devices when Play/Pause doesn\'t work correctly</string>
     <string name="settings.debug.title">Debug options</string>
     <string name="settings.debug.log_to_file">Write debug log to file</string>
     <string name="settings.debug.log_path">The log files are available at %1$s/%2$s</string>

--- a/ultrasonic/src/main/res/xml/settings.xml
+++ b/ultrasonic/src/main/res/xml/settings.xml
@@ -104,14 +104,18 @@
             a:defaultValue="false"
             a:key="@string/settings.playback.resume_play_on_headphones_plug"
             a:title="@string/settings.playback.resume_play_on_headphones_plug.title"
-            a:summary="@string/settings.playback.resume_play_on_headphones_plug.summary"
-            />
+            a:summary="@string/settings.playback.resume_play_on_headphones_plug.summary" />
         <Preference
             a:key="resumeOnBluetoothDevice"
             a:title="@string/settings.playback.resume_on_bluetooth_device"/>
         <Preference
             a:key="pauseOnBluetoothDevice"
             a:title="@string/settings.playback.pause_on_bluetooth_device"/>
+        <CheckBoxPreference
+            a:defaultValue="false"
+            a:key="singleButtonPlayPause"
+            a:summary="@string/settings.playback.single_button_bluetooth_device_summary"
+            a:title="@string/settings.playback.single_button_bluetooth_device"/>
     </PreferenceCategory>
     <PreferenceCategory
         a:title="@string/settings.notifications_title"


### PR DESCRIPTION
Closes #285 
As written in the issue, the problem is that some older Bluetooth devices are sending multiple PLAY keycodes instead of play/pause. It seems before API28 Android translated these, but after the update the devices stopped working correctly.

The solution is very simple, Ultrasonic can translate the keycodes to PLAY_PAUSE, which is already implemented correctly.
