### PR TITLE
Updated API to 29, fixed failing tests

### DIFF
--- a/core/subsonic-api-image-loader/src/integrationTest/kotlin/org/moire/ultrasonic/subsonic/loader/image/CommonFunctions.kt
+++ b/core/subsonic-api-image-loader/src/integrationTest/kotlin/org/moire/ultrasonic/subsonic/loader/image/CommonFunctions.kt
@@ -4,6 +4,6 @@ import java.io.InputStream
 import okio.Okio
 
 fun Any.loadResourceStream(name: String): InputStream {
-    val source = Okio.buffer(Okio.source(javaClass.classLoader.getResourceAsStream(name)))
+    val source = Okio.buffer(Okio.source(javaClass.classLoader!!.getResourceAsStream(name)))
     return source.inputStream()
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
         minSdk               : 14,
-        targetSdk            : 28,
-        compileSdk           : 28,
+        targetSdk            : 29,
+        compileSdk           : 29,
         gradle               : '6.5',
 
         androidTools         : "4.0.0",


### PR DESCRIPTION
Fixes #357 
It seems something was updated in the compiler and now it notices that getClassLoader() may return null. 
I think a not-null-assertion can safely be added, especially as the change only seems to affect the unit tests.