### PR TITLE
Fixed artist items in search

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/ArtistAdapter.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/ArtistAdapter.java
@@ -81,9 +81,8 @@ public class ArtistAdapter extends ArrayAdapter<Artist> implements SectionIndexe
     ) {
         View rowView = convertView;
         if (rowView == null) {
-            rowView = layoutInflater.inflate(R.layout.artist_list_item, parent, false);
+            rowView = layoutInflater.inflate(R.layout.artist_search_list_item, parent, false);
         }
-
         ((TextView) rowView).setText(getItem(position).getName());
 
         return rowView;

--- a/ultrasonic/src/main/res/layout/artist_search_list_item.xml
+++ b/ultrasonic/src/main/res/layout/artist_search_list_item.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:a="http://schemas.android.com/apk/res/android"
+    a:id="@android:id/text1"
+    a:drawablePadding="6dip"
+    a:layout_width="fill_parent"
+    a:layout_height="wrap_content"
+    a:textAppearance="?android:attr/textAppearanceMedium"
+    a:gravity="center_vertical"
+    a:paddingLeft="3dip"
+    a:paddingRight="3dip"
+    a:minHeight="50dip"/>


### PR DESCRIPTION
Fixes #360 

I've checked if the new Artist list item can be used, but 
- there is no meaning for the alphabetic indexing in this list, so it would be hidden anyway
- search doesn't use RecyclerView yet so the new list item can't be used as is

Thus the solution was adding back the old (simple text) layout for Artists in the Search result list.
