### PR TITLE
Fall back to path when comparing tracks

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/EntryByDiscAndTrackComparator.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/EntryByDiscAndTrackComparator.java
@@ -18,6 +18,8 @@ public class EntryByDiscAndTrackComparator implements Comparator<MusicDirectory.
 		Integer trackY = y.getTrack();
 		String albumX = x.getAlbum();
 		String albumY = y.getAlbum();
+		String pathX = x.getPath();
+		String pathY = y.getPath();
 
 		int albumComparison = compare(albumX, albumY);
 
@@ -33,7 +35,14 @@ public class EntryByDiscAndTrackComparator implements Comparator<MusicDirectory.
 			return discComparison;
 		}
 
-		return compare(trackX == null ? 0 : trackX, trackY == null ? 0 : trackY);
+		int trackComparison = compare(trackX == null ? 0 : trackX, trackY == null ? 0 : trackY);
+
+		if (trackComparison != 0)
+		{
+			return trackComparison;
+		}
+
+		return compare(pathX == null ? "" : pathX, pathY == null ? "" : pathY);
 	}
 
 	private static int compare(long a, long b)


### PR DESCRIPTION
Tracks will be sorted by ascending path if neither album, disc and track id can help.

This is helpful for browsing a loose collection of tracks tagged under the same album.

Similar to #219

I've tested the changes in an emulator, with navidrome as a server.