### PR TITLE
Send "Accept" headers in Subsonic API calls

### DIFF
--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIClient.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIClient.kt
@@ -70,7 +70,11 @@ class SubsonicAPIClient(
                 .addQueryParameter("c", config.clientID)
                 .addQueryParameter("f", "json")
                 .build()
-            chain.proceed(originalRequest.newBuilder().url(newUrl).build())
+            var newRequest = originalRequest.newBuilder()
+                .url(newUrl)
+                .header("Accept", "*/*")
+                .build()
+            chain.proceed(newRequest)
         }
         .addInterceptor(versionInterceptor)
         .addInterceptor(proxyPasswordInterceptor)


### PR DESCRIPTION
Some picky servers only responds when this is present (curl sends it by default for example).

I noticed this when trying to a navidrome server running in development mode.