### PR TITLE
Changed how the NowPlaying view is displayed and hidden

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SubsonicTabActivity.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/activity/SubsonicTabActivity.java
@@ -170,6 +170,9 @@ public class SubsonicTabActivity extends ResultActivity implements OnClickListen
 			restart();
 		}
 
+		// This must be filled here because onCreate is called before the derived objects would call setContentView
+		getNowPlayingView();
+
 		if (!nowPlayingHidden)
 		{
 			showNowPlaying();
@@ -242,6 +245,19 @@ public class SubsonicTabActivity extends ResultActivity implements OnClickListen
 		return destroyed;
 	}
 
+	private void getNowPlayingView()
+	{
+		if (nowPlayingView == null)
+		{
+			try {
+				nowPlayingView = findViewById(R.id.now_playing);
+			}
+			catch (Exception exception) {
+				Timber.w(exception, "An exception has occurred while trying to get the nowPlayingView by findViewById");
+			}
+		}
+	}
+
 	public void showNowPlaying()
 	{
 		this.runOnUiThread(new Runnable()
@@ -259,8 +275,6 @@ public class SubsonicTabActivity extends ResultActivity implements OnClickListen
 							hideNowPlaying();
 							return null;
 						}
-
-						nowPlayingView = findViewById(R.id.now_playing);
 
 						if (nowPlayingView != null)
 						{
@@ -305,11 +319,6 @@ public class SubsonicTabActivity extends ResultActivity implements OnClickListen
 		{
 			hideNowPlaying();
 			return;
-		}
-
-		if (nowPlayingView == null)
-		{
-			nowPlayingView = findViewById(R.id.now_playing);
 		}
 
 		if (nowPlayingView != null)
@@ -407,11 +416,6 @@ public class SubsonicTabActivity extends ResultActivity implements OnClickListen
 	{
 		try
 		{
-			if (nowPlayingView == null)
-			{
-				nowPlayingView = findViewById(R.id.now_playing);
-			}
-
 			if (nowPlayingView != null)
 			{
 				setVisibilityOnUiThread(nowPlayingView, View.GONE);


### PR DESCRIPTION
This may fix #369
Generally I think that findViewById should only do what it says in the documentation, return the view if it is found or return null if it isn't - and it shouldn't throw NullPointerException when it encounters null values in a viewGroup while searching for the Id. So there is definitely a problem inside Android, which may or may not be fixed in the future.
However, Ultrasonic called findViewById from random background threads in the SubsonicTabActivity which surely didn't help. I think it is way better to retrieve the view when the Activity is initialized and store it, as the recommended pattern says (and as Ultrasonic does this in other activities).