### PR TITLE
Fixed Next button behavior when Repeat All is enabled

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
@@ -304,15 +304,8 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
                     @Override
                     protected Boolean doInBackground()
                     {
-                        if (mediaPlayerControllerLazy.getValue().getCurrentPlayingNumberOnPlaylist() < mediaPlayerControllerLazy.getValue().getPlaylistSize() - 1)
-                        {
-                            mediaPlayerControllerLazy.getValue().next();
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
+                        mediaPlayerControllerLazy.getValue().next();
+                        return true;
                     }
 
                     @Override

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
@@ -1501,12 +1501,9 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
         if (e1X - e2X > swipeDistance && absX > swipeVelocity)
         {
             networkAndStorageChecker.getValue().warnIfNetworkOrStorageUnavailable();
-            if (mediaPlayerController.getCurrentPlayingNumberOnPlaylist() < mediaPlayerController.getPlaylistSize() - 1)
-            {
-                mediaPlayerController.next();
-                onCurrentChanged();
-                onSliderProgressChanged();
-            }
+            mediaPlayerController.next();
+            onCurrentChanged();
+            onSliderProgressChanged();
             return true;
         }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
@@ -458,7 +458,20 @@ public class MediaPlayerControllerImpl implements MediaPlayerController
 		int index = downloader.getCurrentPlayingIndex();
 		if (index != -1)
 		{
-			play(index + 1);
+			switch (getRepeatMode())
+			{
+				case SINGLE:
+				case OFF:
+					if (index + 1 >= 0 && index + 1 < downloader.downloadList.size()) {
+						play(index + 1);
+					}
+					break;
+				case ALL:
+					play((index + 1) % downloader.downloadList.size());
+					break;
+				default:
+					break;
+			}
 		}
 	}
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
@@ -221,10 +221,7 @@ public class MediaPlayerLifecycleSupport
 						mediaPlayerController.previous();
 						break;
 					case KeyEvent.KEYCODE_MEDIA_NEXT:
-						if (downloader.getCurrentPlayingIndex() < downloader.downloadList.size() - 1)
-						{
-							mediaPlayerController.next();
-						}
+						mediaPlayerController.next();
 						break;
 					case KeyEvent.KEYCODE_MEDIA_STOP:
 						mediaPlayerController.stop();


### PR DESCRIPTION
Fixes #397 
The check to see if there is a next track to play was in many different places in Ultrasonic. Now the "next" command always works the same way, no matter where it is started from - the player interface, bluetooth keys, or the mini-now-playing. 