### PR TITLE
Fixed VideoPlayer using wrong context

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
@@ -104,7 +104,7 @@ public class BookmarksFragment extends Fragment {
                     {
                         if (entry.isVideo())
                         {
-                            videoPlayer.getValue().playVideo(entry);
+                            videoPlayer.getValue().playVideo(getContext(), entry);
                         }
                         else
                         {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
@@ -576,7 +576,7 @@ public class SearchFragment extends Fragment {
 
     private void onVideoSelected(MusicDirectory.Entry entry)
     {
-        videoPlayer.getValue().playVideo(entry);
+        videoPlayer.getValue().playVideo(getContext(), entry);
     }
 
     private void autoplay()

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/MusicServiceModule.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/MusicServiceModule.kt
@@ -85,6 +85,6 @@ val musicServiceModule = module {
 
     single { DownloadHandler(get(), get()) }
     single { NetworkAndStorageChecker(androidContext()) }
-    single { VideoPlayer(androidContext()) }
+    single { VideoPlayer() }
     single { ShareHandler(androidContext()) }
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
@@ -134,7 +134,7 @@ class SelectAlbumFragment : Fragment() {
                             bundle
                         )
                     } else if (entry != null && entry.isVideo) {
-                        videoPlayer.playVideo(entry)
+                        videoPlayer.playVideo(requireContext(), entry)
                     } else {
                         enableButtons()
                     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -649,7 +649,7 @@ open class RESTMusicService(
             "Get-Video-Url"
         ).start()
 
-        latch.await(3, TimeUnit.SECONDS)
+        latch.await(5, TimeUnit.SECONDS)
 
         return expectedResult[0]!!
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/VideoPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/VideoPlayer.kt
@@ -8,8 +8,8 @@ import org.moire.ultrasonic.util.Util
 /**
  * This utility class helps starting video playback
  */
-class VideoPlayer(val context: Context) {
-    fun playVideo(entry: MusicDirectory.Entry?) {
+class VideoPlayer() {
+    fun playVideo(context: Context, entry: MusicDirectory.Entry?) {
         if (!Util.isNetworkConnected(context)) {
             Util.toast(context, R.string.select_album_no_network)
             return
@@ -18,7 +18,7 @@ class VideoPlayer(val context: Context) {
         try {
             player.playVideo(context, entry)
         } catch (e: Exception) {
-            Util.toast(context, e.message, false)
+            Util.toast(context, e.toString(), false)
         }
     }
 }


### PR DESCRIPTION
Fixes #407 
This was a simple bug, VideoPlayer was using ApplicationContext where only ActivityContext would work. The solution was to pass down the ActivityContext as a parameter.