### PR TITLE
Clean empty text view

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
@@ -1118,12 +1118,11 @@ class SelectAlbumFragment : Fragment() {
             playAllButtonVisible = !(isAlbumList || entries.isEmpty()) && !allVideos
             shareButtonVisible = !isOffline(context) && songCount > 0
 
+            albumListView!!.removeHeaderView(emptyView!!)
             if (entries.isEmpty()) {
                 emptyView!!.text = "No Media Found"
                 emptyView!!.setPadding(10, 10, 10, 10)
                 albumListView!!.addHeaderView(emptyView, null, false)
-            } else {
-                albumListView!!.removeHeaderView(emptyView!!)
             }
 
             if (playAllButton != null) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
@@ -74,7 +74,7 @@ class SelectAlbumFragment : Fragment() {
     private var header: View? = null
     private var selectFolderHeader: SelectMusicFolderView? = null
     private var albumButtons: View? = null
-    private var emptyView: View? = null
+    private var emptyView: TextView? = null
     private var selectButton: ImageView? = null
     private var playNowButton: ImageView? = null
     private var playNextButton: ImageView? = null
@@ -217,7 +217,7 @@ class SelectAlbumFragment : Fragment() {
         downloadButton = view.findViewById(R.id.select_album_download)
         deleteButton = view.findViewById(R.id.select_album_delete)
         moreButton = view.findViewById(R.id.select_album_more)
-        emptyView = view.findViewById(R.id.select_album_empty)
+        emptyView = TextView(requireContext())
 
         selectButton!!.setOnClickListener(
             View.OnClickListener
@@ -1118,7 +1118,13 @@ class SelectAlbumFragment : Fragment() {
             playAllButtonVisible = !(isAlbumList || entries.isEmpty()) && !allVideos
             shareButtonVisible = !isOffline(context) && songCount > 0
 
-            emptyView!!.visibility = if (entries.isEmpty()) View.VISIBLE else View.GONE
+            if (entries.isEmpty()) {
+                emptyView!!.text = "No Media Found"
+                emptyView!!.setPadding(10, 10, 10, 10)
+                albumListView!!.addHeaderView(emptyView, null, false)
+            } else {
+                albumListView!!.removeHeaderView(emptyView!!)
+            }
 
             if (playAllButton != null) {
                 playAllButton!!.isVisible = playAllButtonVisible


### PR DESCRIPTION
A continuation and cleanup from https://github.com/ultrasonic/ultrasonic/pull/410

The "No media found" text was appearing stubbornly on top of the `SelectMusicFolderView`. This fix leaves the original TextView hidden (because some other screens still use it) and instead simply adds a second header to reproduce the message. 

Signed-off-by: James Wells <james@jameswells.net>