### PR TITLE
Add a retry count to stop infinite downloads

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/Downloader.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/Downloader.java
@@ -194,6 +194,12 @@ public class Downloader
                     revision++;
                     i--;
                 }
+                else if (downloadFile.isFailed() && !downloadFile.shouldRetry()) {
+                    // Don't continue to attempt to download forever
+                    backgroundDownloadList.remove(i);
+                    revision++;
+                    i--;
+                }
                 else
                 {
                     currentDownloading = downloadFile;

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
@@ -45,6 +45,7 @@ class DownloadFile(
     private val mediaStoreService: MediaStoreService
     private var downloadTask: CancellableTask? = null
     var isFailed = false
+    private var retryCount = 5
 
     private val desiredBitRate: Int = Util.getMaxBitRate(context)
 
@@ -125,6 +126,10 @@ class DownloadFile(
 
     fun shouldSave(): Boolean {
         return save
+    }
+
+    fun shouldRetry(): Boolean {
+        return (retryCount > 0)
     }
 
     fun delete() {
@@ -288,6 +293,9 @@ class DownloadFile(
                 Util.delete(saveFile)
                 if (!isCancelled) {
                     isFailed = true
+                    if (retryCount > 0) {
+                        --retryCount
+                    }
                     Timber.w(x, "Failed to download '%s'.", song)
                 }
             } finally {


### PR DESCRIPTION
See also: https://github.com/ultrasonic/ultrasonic/issues/416

The `Downloader` class keeps a list of background files to download. A separate thread will check on the downloads every five seconds. When a download fails for some reason it will be re-attempted. Unfortunately there is no cutoff, so a file will be re-downloaded forever. This can have a serious impact on monthly bandwidth charges.

This fix introduces a simple `retryCount` to the `DownloadFile` class. On each failure the count will be decremented. If the count gets to zero then a new `shouldRetry()` function will return false. The `Downloader` class will check for this condition and stop attempting to download if it is hit.

While this fix does work I worry that it may be overly simplistic. I am not familiar with the entire download mechanism and I see that it's used very widely throughout the system. My hope is that one of the reviewers will have more familiarity and can spot potential issues. The last thing I want to do is add another edge case.

Signed-off-by: James Wells <james@jameswells.net>