### PR TITLE
Refactor SelectAlbumView using ViewModel pattern

### DIFF
--- a/detekt-baseline-debug.xml
+++ b/detekt-baseline-debug.xml
@@ -33,7 +33,7 @@
     <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !deleteEnabled &amp;&amp; !isOffline(context)</ID>
     <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !isOffline(context) &amp;&amp; selection.size &gt; pinnedCount</ID>
     <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$entry != null &amp;&amp; !entry.isDirectory &amp;&amp; !entry.isVideo</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment.&lt;no name provided&gt;$Util.getShouldShowAllSongsByArtist(context) &amp;&amp; musicDirectory.findChild(allSongsId) == null &amp;&amp; musicDirectory.getChildren(true, false).size == musicDirectory.getChildren(true, true).size</ID>
+    <ID>ComplexCondition:SelectAlbumModel.kt$SelectAlbumModel$Util.getShouldShowAllSongsByArtist(context) &amp;&amp; musicDirectory.findChild(allSongsId) == null &amp;&amp; musicDirectory.getChildren(true, false).size == musicDirectory.getChildren(true, true).size</ID>
     <ID>ComplexCondition:ServerSettingsModel.kt$ServerSettingsModel$url.isNullOrEmpty() || userName.isNullOrEmpty() || isMigrated</ID>
     <ID>ComplexCondition:SongView.kt$SongView$TextUtils.isEmpty(transcodedSuffix) || transcodedSuffix == suffix || song.isVideo &amp;&amp; Util.getVideoPlayerType(this.context) !== VideoPlayerType.FLASH</ID>
     <ID>ComplexCondition:SubsonicImageLoaderProxy.kt$SubsonicImageLoaderProxy$id != null &amp;&amp; view != null &amp;&amp; view is ImageView</ID>
@@ -49,10 +49,9 @@
     <ID>ComplexMethod:MediaPlayerService.kt$MediaPlayerService$private fun setupOnSongCompletedHandler()</ID>
     <ID>ComplexMethod:RestErrorMapper.kt$ fun SubsonicRESTException.getLocalizedErrorMessage(context: Context): String</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onContextItemSelected(menuItem: MenuItem): Boolean</ID>
-    <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun enableButtons()</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateDisplay(refresh: Boolean)</ID>
-    <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$protected override fun done(result: Pair&lt;MusicDirectory, Boolean&gt;)</ID>
+    <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateInterfaceWithEntries(musicDirectory: MusicDirectory)</ID>
     <ID>ComplexMethod:SelectArtistFragment.kt$SelectArtistFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:ServerRowAdapter.kt$ServerRowAdapter$ override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View?</ID>
     <ID>ComplexMethod:SongView.kt$SongView$fun setSong(song: MusicDirectory.Entry, checkable: Boolean, draggable: Boolean)</ID>
@@ -85,9 +84,9 @@
     <ID>LargeClass:NavigationActivity.kt$NavigationActivity : AppCompatActivity</ID>
     <ID>LargeClass:RESTMusicService.kt$RESTMusicService : MusicService</ID>
     <ID>LargeClass:SelectAlbumFragment.kt$SelectAlbumFragment : Fragment</ID>
-    <ID>LargeClass:SelectAlbumFragment.kt$SelectAlbumFragment$LoadTask : FragmentBackgroundTask</ID>
+    <ID>LargeClass:SelectAlbumModel.kt$SelectAlbumModel : AndroidViewModelKoinComponent</ID>
     <ID>LargeClass:SelectArtistFragment.kt$SelectArtistFragment : Fragment</ID>
-    <ID>LargeClass:ServerSettingsModel.kt$ServerSettingsModel : ViewModel</ID>
+    <ID>LargeClass:ServerSettingsModel.kt$ServerSettingsModel : AndroidViewModel</ID>
     <ID>LargeClass:SongView.kt$SongView : UpdateViewCheckable</ID>
     <ID>LongMethod:APIMusicDirectoryConverter.kt$fun MusicDirectoryChild.toDomainEntity(): MusicDirectory.Entry</ID>
     <ID>LongMethod:ActiveServerProvider.kt$ActiveServerProvider$ fun getActiveServer(): ServerSetting</ID>
@@ -140,14 +139,16 @@
     <ID>LongMethod:RestErrorMapper.kt$ fun SubsonicRESTException.getLocalizedErrorMessage(context: Context): String</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onContextItemSelected(menuItem: MenuItem): Boolean</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
+    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun createHeader( entries: List&lt;MusicDirectory.Entry&gt;, name: CharSequence?, songCount: Int ): View?</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun downloadBackground(save: Boolean, songs: List&lt;MusicDirectory.Entry?&gt;)</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun enableButtons()</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun playAll(shuffle: Boolean = false, append: Boolean = false)</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateDisplay(refresh: Boolean)</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.&lt;no name provided&gt;$override fun done(result: Pair&lt;MusicDirectory, Boolean&gt;)</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.&lt;no name provided&gt;$override fun load(service: MusicService): MusicDirectory</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$protected fun createHeader( entries: List&lt;MusicDirectory.Entry&gt;, name: CharSequence?, songCount: Int ): View?</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$protected override fun done(result: Pair&lt;MusicDirectory, Boolean&gt;)</ID>
+    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateInterfaceWithEntries(musicDirectory: MusicDirectory)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getAlbum(refresh: Boolean, id: String?, name: String?, parentId: String?)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getAlbumList(albumListType: String, size: Int, offset: Int)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getArtist(refresh: Boolean, id: String?, name: String?)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getMusicDirectory( refresh: Boolean, id: String?, name: String?, parentId: String? )</ID>
     <ID>LongMethod:SelectArtistFragment.kt$SelectArtistFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:SelectArtistFragment.kt$SelectArtistFragment$private fun onArtistMenuItemSelected(menuItem: MenuItem, artist: Artist): Boolean</ID>
     <ID>LongMethod:ServerRowAdapter.kt$ServerRowAdapter$ override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View?</ID>
@@ -204,7 +205,6 @@
     <ID>MagicNumber:RESTMusicService.kt$RESTMusicService$206</ID>
     <ID>MagicNumber:RESTMusicService.kt$RESTMusicService$5</ID>
     <ID>MagicNumber:SelectAlbumFragment.kt$SelectAlbumFragment$10</ID>
-    <ID>MagicNumber:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$10</ID>
     <ID>MagicNumber:SelectMusicFolderView.kt$SelectMusicFolderView$10</ID>
     <ID>MagicNumber:SongView.kt$SongView$3</ID>
     <ID>MagicNumber:SongView.kt$SongView$4</ID>
@@ -212,7 +212,6 @@
     <ID>NestedBlockDepth:DownloadFile.kt$DownloadFile.DownloadTask$override fun execute()</ID>
     <ID>NestedBlockDepth:DownloadHandler.kt$DownloadHandler$private fun downloadRecursively( fragment: Fragment, id: String, name: String?, isShare: Boolean, isDirectory: Boolean, save: Boolean, append: Boolean, autoPlay: Boolean, shuffle: Boolean, background: Boolean, playNext: Boolean, unpin: Boolean, isArtist: Boolean )</ID>
     <ID>NestedBlockDepth:MediaPlayerService.kt$MediaPlayerService$private fun setupOnSongCompletedHandler()</ID>
-    <ID>NestedBlockDepth:SelectAlbumFragment.kt$SelectAlbumFragment$private fun getAlbum(refresh: Boolean, id: String?, name: String?, parentId: String?)</ID>
     <ID>ReturnCount:ActiveServerProvider.kt$ActiveServerProvider$ fun getActiveServer(): ServerSetting</ID>
     <ID>ReturnCount:CommunicationErrorHandler.kt$CommunicationErrorHandler.Companion$fun getErrorMessage(error: Throwable, context: Context): String</ID>
     <ID>ReturnCount:FileLoggerTree.kt$FileLoggerTree$ private fun getNextLogFile()</ID>
@@ -241,7 +240,6 @@
     <ID>TooGenericExceptionCaught:LocalMediaPlayer.kt$LocalMediaPlayer.PositionCache$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MediaPlayerService.kt$MediaPlayerService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MediaPlayerService.kt$MediaPlayerService$x: IndexOutOfBoundsException</ID>
-    <ID>TooGenericExceptionCaught:SelectAlbumFragment.kt$SelectAlbumFragment$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:SongView.kt$SongView$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SubsonicUncaughtExceptionHandler.kt$SubsonicUncaughtExceptionHandler$x: Throwable</ID>
     <ID>TooGenericExceptionCaught:VideoPlayer.kt$VideoPlayer$e: Exception</ID>

--- a/detekt-baseline-release.xml
+++ b/detekt-baseline-release.xml
@@ -33,7 +33,7 @@
     <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !deleteEnabled &amp;&amp; !isOffline(context)</ID>
     <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !isOffline(context) &amp;&amp; selection.size &gt; pinnedCount</ID>
     <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$entry != null &amp;&amp; !entry.isDirectory &amp;&amp; !entry.isVideo</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment.&lt;no name provided&gt;$Util.getShouldShowAllSongsByArtist(context) &amp;&amp; musicDirectory.findChild(allSongsId) == null &amp;&amp; musicDirectory.getChildren(true, false).size == musicDirectory.getChildren(true, true).size</ID>
+    <ID>ComplexCondition:SelectAlbumModel.kt$SelectAlbumModel$Util.getShouldShowAllSongsByArtist(context) &amp;&amp; musicDirectory.findChild(allSongsId) == null &amp;&amp; musicDirectory.getChildren(true, false).size == musicDirectory.getChildren(true, true).size</ID>
     <ID>ComplexCondition:ServerSettingsModel.kt$ServerSettingsModel$url.isNullOrEmpty() || userName.isNullOrEmpty() || isMigrated</ID>
     <ID>ComplexCondition:SongView.kt$SongView$TextUtils.isEmpty(transcodedSuffix) || transcodedSuffix == suffix || song.isVideo &amp;&amp; Util.getVideoPlayerType(this.context) !== VideoPlayerType.FLASH</ID>
     <ID>ComplexCondition:SubsonicImageLoaderProxy.kt$SubsonicImageLoaderProxy$id != null &amp;&amp; view != null &amp;&amp; view is ImageView</ID>
@@ -49,10 +49,11 @@
     <ID>ComplexMethod:MediaPlayerService.kt$MediaPlayerService$private fun setupOnSongCompletedHandler()</ID>
     <ID>ComplexMethod:RestErrorMapper.kt$ fun SubsonicRESTException.getLocalizedErrorMessage(context: Context): String</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onContextItemSelected(menuItem: MenuItem): Boolean</ID>
-    <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun enableButtons()</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateDisplay(refresh: Boolean)</ID>
-    <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$protected override fun done(result: Pair&lt;MusicDirectory, Boolean&gt;)</ID>
+    <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateInterfaceWithEntries(musicDirectory: MusicDirectory)</ID>
+    <ID>ComplexMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getAlbumList(albumListType: String, size: Int, offset: Int)</ID>
+    <ID>ComplexMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getMusicDirectory( refresh: Boolean, id: String?, name: String?, parentId: String? )</ID>
     <ID>ComplexMethod:SelectArtistFragment.kt$SelectArtistFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:ServerRowAdapter.kt$ServerRowAdapter$ override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View?</ID>
     <ID>ComplexMethod:SongView.kt$SongView$fun setSong(song: MusicDirectory.Entry, checkable: Boolean, draggable: Boolean)</ID>
@@ -85,9 +86,9 @@
     <ID>LargeClass:NavigationActivity.kt$NavigationActivity : AppCompatActivity</ID>
     <ID>LargeClass:RESTMusicService.kt$RESTMusicService : MusicService</ID>
     <ID>LargeClass:SelectAlbumFragment.kt$SelectAlbumFragment : Fragment</ID>
-    <ID>LargeClass:SelectAlbumFragment.kt$SelectAlbumFragment$LoadTask : FragmentBackgroundTask</ID>
+    <ID>LargeClass:SelectAlbumModel.kt$SelectAlbumModel : AndroidViewModelKoinComponent</ID>
     <ID>LargeClass:SelectArtistFragment.kt$SelectArtistFragment : Fragment</ID>
-    <ID>LargeClass:ServerSettingsModel.kt$ServerSettingsModel : ViewModel</ID>
+    <ID>LargeClass:ServerSettingsModel.kt$ServerSettingsModel : AndroidViewModel</ID>
     <ID>LargeClass:SongView.kt$SongView : UpdateViewCheckable</ID>
     <ID>LongMethod:APIMusicDirectoryConverter.kt$fun MusicDirectoryChild.toDomainEntity(): MusicDirectory.Entry</ID>
     <ID>LongMethod:ActiveServerProvider.kt$ActiveServerProvider$ fun getActiveServer(): ServerSetting</ID>
@@ -140,14 +141,16 @@
     <ID>LongMethod:RestErrorMapper.kt$ fun SubsonicRESTException.getLocalizedErrorMessage(context: Context): String</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onContextItemSelected(menuItem: MenuItem): Boolean</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
+    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun createHeader( entries: List&lt;MusicDirectory.Entry&gt;, name: CharSequence?, songCount: Int ): View?</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun downloadBackground(save: Boolean, songs: List&lt;MusicDirectory.Entry?&gt;)</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun enableButtons()</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun playAll(shuffle: Boolean = false, append: Boolean = false)</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateDisplay(refresh: Boolean)</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.&lt;no name provided&gt;$override fun done(result: Pair&lt;MusicDirectory, Boolean&gt;)</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.&lt;no name provided&gt;$override fun load(service: MusicService): MusicDirectory</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$protected fun createHeader( entries: List&lt;MusicDirectory.Entry&gt;, name: CharSequence?, songCount: Int ): View?</ID>
-    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$protected override fun done(result: Pair&lt;MusicDirectory, Boolean&gt;)</ID>
+    <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateInterfaceWithEntries(musicDirectory: MusicDirectory)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getAlbum(refresh: Boolean, id: String?, name: String?, parentId: String?)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getAlbumList(albumListType: String, size: Int, offset: Int)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getArtist(refresh: Boolean, id: String?, name: String?)</ID>
+    <ID>LongMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getMusicDirectory( refresh: Boolean, id: String?, name: String?, parentId: String? )</ID>
     <ID>LongMethod:SelectArtistFragment.kt$SelectArtistFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:SelectArtistFragment.kt$SelectArtistFragment$private fun onArtistMenuItemSelected(menuItem: MenuItem, artist: Artist): Boolean</ID>
     <ID>LongMethod:ServerRowAdapter.kt$ServerRowAdapter$ override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View?</ID>
@@ -204,7 +207,6 @@
     <ID>MagicNumber:RESTMusicService.kt$RESTMusicService$206</ID>
     <ID>MagicNumber:RESTMusicService.kt$RESTMusicService$5</ID>
     <ID>MagicNumber:SelectAlbumFragment.kt$SelectAlbumFragment$10</ID>
-    <ID>MagicNumber:SelectAlbumFragment.kt$SelectAlbumFragment.LoadTask$10</ID>
     <ID>MagicNumber:SelectMusicFolderView.kt$SelectMusicFolderView$10</ID>
     <ID>MagicNumber:SongView.kt$SongView$3</ID>
     <ID>MagicNumber:SongView.kt$SongView$4</ID>
@@ -212,7 +214,6 @@
     <ID>NestedBlockDepth:DownloadFile.kt$DownloadFile.DownloadTask$override fun execute()</ID>
     <ID>NestedBlockDepth:DownloadHandler.kt$DownloadHandler$private fun downloadRecursively( fragment: Fragment, id: String, name: String?, isShare: Boolean, isDirectory: Boolean, save: Boolean, append: Boolean, autoPlay: Boolean, shuffle: Boolean, background: Boolean, playNext: Boolean, unpin: Boolean, isArtist: Boolean )</ID>
     <ID>NestedBlockDepth:MediaPlayerService.kt$MediaPlayerService$private fun setupOnSongCompletedHandler()</ID>
-    <ID>NestedBlockDepth:SelectAlbumFragment.kt$SelectAlbumFragment$private fun getAlbum(refresh: Boolean, id: String?, name: String?, parentId: String?)</ID>
     <ID>ReturnCount:ActiveServerProvider.kt$ActiveServerProvider$ fun getActiveServer(): ServerSetting</ID>
     <ID>ReturnCount:CommunicationErrorHandler.kt$CommunicationErrorHandler.Companion$fun getErrorMessage(error: Throwable, context: Context): String</ID>
     <ID>ReturnCount:FileLoggerTree.kt$FileLoggerTree$ private fun getNextLogFile()</ID>
@@ -241,7 +242,6 @@
     <ID>TooGenericExceptionCaught:LocalMediaPlayer.kt$LocalMediaPlayer.PositionCache$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MediaPlayerService.kt$MediaPlayerService$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MediaPlayerService.kt$MediaPlayerService$x: IndexOutOfBoundsException</ID>
-    <ID>TooGenericExceptionCaught:SelectAlbumFragment.kt$SelectAlbumFragment$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:SongView.kt$SongView$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SubsonicUncaughtExceptionHandler.kt$SubsonicUncaughtExceptionHandler$x: Throwable</ID>
     <ID>TooGenericExceptionCaught:VideoPlayer.kt$VideoPlayer$e: Exception</ID>

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -49,8 +49,6 @@ complexity:
     thresholdInFiles: 20
     thresholdInClasses: 20
     thresholdInInterfaces: 20
-  ComplexCondition:
-    threshold: 3
   LabeledExpression:
     active: false
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/EntryAdapter.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/EntryAdapter.java
@@ -33,6 +33,8 @@ import org.moire.ultrasonic.util.ImageLoader;
 import java.util.List;
 
 /**
+ * This is the adapter for the display of a single list item (song, album, etc)
+ *
  * @author Sindre Mehus
  */
 public class EntryAdapter extends ArrayAdapter<Entry>

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/UpdateView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/UpdateView.java
@@ -14,6 +14,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.WeakHashMap;
 
+/**
+ * A View that is periodically refreshed
+ * @deprecated
+ * Use LiveData to ensure that the content is up-to-date
+ **/
+@Deprecated
 public class UpdateView extends LinearLayout
 {
 	private static final WeakHashMap<UpdateView, ?> INSTANCES = new WeakHashMap<UpdateView, Object>();

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/UpdateView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/UpdateView.java
@@ -19,7 +19,6 @@ import java.util.WeakHashMap;
  * @deprecated
  * Use LiveData to ensure that the content is up-to-date
  **/
-@Deprecated
 public class UpdateView extends LinearLayout
 {
 	private static final WeakHashMap<UpdateView, ?> INSTANCES = new WeakHashMap<UpdateView, Object>();

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/AppPermanentStorageModule.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/AppPermanentStorageModule.kt
@@ -31,5 +31,5 @@ val appPermanentStorage = module {
 
     single { get<AppDatabase>().serverSettingDao() }
 
-    viewModel { ServerSettingsModel(get(), get(), androidContext()) }
+    viewModel { ServerSettingsModel(get(), get(), get()) }
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
@@ -278,7 +278,7 @@ class SelectAlbumFragment : Fragment() {
                 model.getPodcastEpisodes(podcastChannelId)
             } else if (shareId != null) {
                 setTitle(shareName)
-                model.getShare(shareId, shareName)
+                model.getShare(shareId)
             } else if (albumListType != null) {
                 setTitle(albumListTitle)
                 model.getAlbumList(albumListType, albumListSize, albumListOffset)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
@@ -31,6 +31,7 @@ import java.util.Collections
 import java.util.Random
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
+import org.koin.android.viewmodel.ext.android.viewModel
 import org.koin.core.component.KoinApiExtension
 import org.moire.ultrasonic.R
 import org.moire.ultrasonic.data.ActiveServerProvider
@@ -92,7 +93,7 @@ class SelectAlbumFragment : Fragment() {
     private var cancellationToken: CancellationToken? = null
     private val activeServerProvider: ActiveServerProvider by inject()
 
-    private val serverSettingsModel: ServerSettingsModel by viewModels()
+    private val serverSettingsModel: ServerSettingsModel by viewModel()
     private val model: SelectAlbumModel by viewModels()
 
     private val random: Random = SecureRandom()
@@ -265,7 +266,7 @@ class SelectAlbumFragment : Fragment() {
             setTitle(this@SelectAlbumFragment, name)
         }
 
-        serverSettingsModel.viewModelScope.launch {
+        model.viewModelScope.launch {
             refreshAlbumListView!!.isRefreshing = true
 
             model.getMusicFolders(refresh)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
@@ -1,0 +1,358 @@
+package org.moire.ultrasonic.fragment
+
+import android.app.Application
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
+import java.util.LinkedList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.moire.ultrasonic.R
+import org.moire.ultrasonic.api.subsonic.models.AlbumListType
+import org.moire.ultrasonic.data.ActiveServerProvider
+import org.moire.ultrasonic.domain.MusicDirectory
+import org.moire.ultrasonic.domain.MusicFolder
+import org.moire.ultrasonic.service.CommunicationErrorHandler
+import org.moire.ultrasonic.service.MusicServiceFactory
+import org.moire.ultrasonic.util.Util
+
+// TODO: Break up this class into smaller more specific classes, extending a base class if necessary
+@KoinApiExtension
+class SelectAlbumModel(application: Application) : AndroidViewModel(application), KoinComponent {
+
+    private val context = getApplication<Application>().applicationContext
+
+    private val activeServerProvider: ActiveServerProvider by inject()
+
+    private val allSongsId = "-1"
+
+    val musicFolders: MutableLiveData<List<MusicFolder>> = MutableLiveData()
+    val albumList: MutableLiveData<MusicDirectory> = MutableLiveData()
+    val currentDirectory: MutableLiveData<MusicDirectory> = MutableLiveData()
+    val songsForGenre: MutableLiveData<MusicDirectory> = MutableLiveData()
+
+    var currentDirectoryIsSortable = true
+    var showHeader = true
+    var showSelectFolderHeader = false
+
+    suspend fun getMusicFolders(refresh: Boolean) {
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val musicService = MusicServiceFactory.getMusicService(context)
+                try {
+                    musicFolders.postValue(musicService.getMusicFolders(refresh, context))
+                } catch (exception: Exception) {
+                    Handler(Looper.getMainLooper()).post {
+                        CommunicationErrorHandler.handleError(exception, context)
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun getMusicDirectory(
+        refresh: Boolean,
+        id: String?,
+        name: String?,
+        parentId: String?
+    ) {
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+
+                var root = MusicDirectory()
+
+                if (allSongsId == id) {
+                    val musicDirectory = service.getMusicDirectory(
+                        parentId, name, refresh, context
+                    )
+
+                    val songs: MutableList<MusicDirectory.Entry> = LinkedList()
+                    getSongsRecursively(musicDirectory, songs)
+
+                    for (song in songs) {
+                        if (!song.isDirectory) {
+                            root.addChild(song)
+                        }
+                    }
+                } else {
+                    val musicDirectory = service.getMusicDirectory(id, name, refresh, context)
+
+                    if (Util.getShouldShowAllSongsByArtist(context) &&
+                        musicDirectory.findChild(allSongsId) == null &&
+                        hasOnlyFolders(musicDirectory)
+                    ) {
+                        val allSongs = MusicDirectory.Entry()
+
+                        allSongs.isDirectory = true
+                        allSongs.artist = name
+                        allSongs.parent = id
+                        allSongs.id = allSongsId
+                        allSongs.title = String.format(
+                            context.resources.getString(R.string.select_album_all_songs), name
+                        )
+
+                        root.addChild(allSongs)
+                        root.addAll(musicDirectory.getChildren())
+                    } else {
+                        root = musicDirectory
+                    }
+                }
+
+                currentDirectory.postValue(root)
+            }
+        }
+    }
+
+    // Given a Music directory "songs" it recursively adds all children to "songs"
+    private fun getSongsRecursively(
+        parent: MusicDirectory,
+        songs: MutableList<MusicDirectory.Entry>
+    ) {
+        val service = MusicServiceFactory.getMusicService(context)
+
+        for (song in parent.getChildren(includeDirs = false, includeFiles = true)) {
+            if (!song.isVideo && !song.isDirectory) {
+                songs.add(song)
+            }
+        }
+
+        for ((id1, _, _, title) in parent.getChildren(true, includeFiles = false)) {
+            var root: MusicDirectory
+
+            if (allSongsId != id1) {
+                root = service.getMusicDirectory(id1, title, false, context)
+
+                getSongsRecursively(root, songs)
+            }
+        }
+    }
+
+    suspend fun getArtist(refresh: Boolean, id: String?, name: String?) {
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+
+                var root = MusicDirectory()
+
+                val musicDirectory = service.getArtist(id, name, refresh, context)
+
+                if (Util.getShouldShowAllSongsByArtist(context) &&
+                    musicDirectory.findChild(allSongsId) == null &&
+                    hasOnlyFolders(musicDirectory)
+                ) {
+                    val allSongs = MusicDirectory.Entry()
+
+                    allSongs.isDirectory = true
+                    allSongs.artist = name
+                    allSongs.parent = id
+                    allSongs.id = allSongsId
+                    allSongs.title = String.format(
+                        context.resources.getString(R.string.select_album_all_songs), name
+                    )
+
+                    root.addFirst(allSongs)
+                    root.addAll(musicDirectory.getChildren())
+                } else {
+                    root = musicDirectory
+                }
+                currentDirectory.postValue(root)
+            }
+        }
+    }
+
+    suspend fun getAlbum(refresh: Boolean, id: String?, name: String?, parentId: String?) {
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+
+                val service = MusicServiceFactory.getMusicService(context)
+
+                val musicDirectory: MusicDirectory
+
+                musicDirectory = if (allSongsId == id) {
+                    val root = MusicDirectory()
+
+                    val songs: MutableCollection<MusicDirectory.Entry> = LinkedList()
+                    val artist = service.getArtist(parentId, "", false, context)
+
+                    for ((id1) in artist.getChildren()) {
+                        if (allSongsId != id1) {
+                            val albumDirectory = service.getAlbum(
+                                id1, "", false, context
+                            )
+
+                            for (song in albumDirectory.getChildren()) {
+                                if (!song.isVideo) {
+                                    songs.add(song)
+                                }
+                            }
+                        }
+                    }
+
+                    for (song in songs) {
+                        if (!song.isDirectory) {
+                            root.addChild(song)
+                        }
+                    }
+                    root
+                } else {
+                    service.getAlbum(id, name, refresh, context)
+                }
+                currentDirectory.postValue(musicDirectory)
+            }
+        }
+    }
+
+    suspend fun getSongsForGenre(genre: String, count: Int, offset: Int) {
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+                val musicDirectory = service.getSongsByGenre(genre, count, offset, context)
+                songsForGenre.postValue(musicDirectory)
+            }
+        }
+    }
+
+    suspend fun getStarred() {
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+
+                val service = MusicServiceFactory.getMusicService(context)
+                val musicDirectory: MusicDirectory
+                val context = context
+
+                if (Util.getShouldUseId3Tags(context)) {
+                    musicDirectory = Util.getSongsFromSearchResult(service.getStarred2(context))
+                } else {
+                    musicDirectory = Util.getSongsFromSearchResult(service.getStarred(context))
+                }
+
+                currentDirectory.postValue(musicDirectory)
+            }
+        }
+    }
+
+    suspend fun getVideos(refresh: Boolean) {
+        showHeader = false
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+                currentDirectory.postValue(service.getVideos(refresh, context))
+            }
+        }
+    }
+
+    suspend fun getRandom(size: Int) {
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+                val musicDirectory = service.getRandomSongs(size, context)
+
+                currentDirectoryIsSortable = false
+                currentDirectory.postValue(musicDirectory)
+            }
+        }
+    }
+
+    suspend fun getPlaylist(playlistId: String, playlistName: String?) {
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+                val musicDirectory = service.getPlaylist(playlistId, playlistName, context)
+
+                currentDirectory.postValue(musicDirectory)
+            }
+        }
+    }
+
+    suspend fun getPodcastEpisodes(podcastChannelId: String) {
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+                val musicDirectory = service.getPodcastEpisodes(podcastChannelId, context)
+                currentDirectory.postValue(musicDirectory)
+            }
+        }
+    }
+
+    suspend fun getShare(shareId: String, shareName: CharSequence?) {
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+                val musicDirectory = MusicDirectory()
+
+                val shares = service.getShares(true, context)
+
+                for (share in shares) {
+                    if (share.id == shareId) {
+                        for (entry in share.getEntries()) {
+                            musicDirectory.addChild(entry)
+                        }
+                        break
+                    }
+                }
+                currentDirectory.postValue(musicDirectory)
+            }
+        }
+    }
+
+    suspend fun getAlbumList(albumListType: String, size: Int, offset: Int) {
+
+        showHeader = false
+        showSelectFolderHeader = !ActiveServerProvider.isOffline(context) &&
+            !Util.getShouldUseId3Tags(context) && (
+            (albumListType == AlbumListType.SORTED_BY_NAME.toString()) ||
+                (albumListType == AlbumListType.SORTED_BY_ARTIST.toString())
+            )
+
+        withContext(Dispatchers.IO) {
+            if (!ActiveServerProvider.isOffline(context)) {
+                val service = MusicServiceFactory.getMusicService(context)
+                val musicDirectory: MusicDirectory
+                val musicFolderId = if (showSelectFolderHeader) {
+                    activeServerProvider.getActiveServer().musicFolderId
+                } else {
+                    null
+                }
+
+                if (Util.getShouldUseId3Tags(context)) {
+                    musicDirectory = service.getAlbumList2(
+                        albumListType, size,
+                        offset, musicFolderId, context
+                    )
+                } else {
+                    musicDirectory = service.getAlbumList(
+                        albumListType, size,
+                        offset, musicFolderId, context
+                    )
+                }
+
+                currentDirectoryIsSortable = sortableCollection(albumListType)
+                albumList.postValue(musicDirectory)
+            }
+        }
+    }
+
+    private fun sortableCollection(albumListType: String): Boolean {
+        return albumListType != "newest" && albumListType != "random" &&
+            albumListType != "highest" && albumListType != "recent" &&
+            albumListType != "frequent"
+    }
+
+    // Returns true if the directory contains only folders
+    private fun hasOnlyFolders(musicDirectory: MusicDirectory) =
+        musicDirectory.getChildren(includeDirs = true, includeFiles = false).size ==
+            musicDirectory.getChildren(includeDirs = true, includeFiles = true).size
+}

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
@@ -1,8 +1,7 @@
 package org.moire.ultrasonic.fragment
 
 import android.app.Application
-import android.os.Handler
-import android.os.Looper
+import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import java.util.LinkedList
@@ -16,7 +15,6 @@ import org.moire.ultrasonic.api.subsonic.models.AlbumListType
 import org.moire.ultrasonic.data.ActiveServerProvider
 import org.moire.ultrasonic.domain.MusicDirectory
 import org.moire.ultrasonic.domain.MusicFolder
-import org.moire.ultrasonic.service.CommunicationErrorHandler
 import org.moire.ultrasonic.service.MusicServiceFactory
 import org.moire.ultrasonic.util.Util
 
@@ -24,7 +22,8 @@ import org.moire.ultrasonic.util.Util
 @KoinApiExtension
 class SelectAlbumModel(application: Application) : AndroidViewModel(application), KoinComponent {
 
-    private val context = getApplication<Application>().applicationContext
+    private val context: Context
+        get() = getApplication<Application>().applicationContext
 
     private val activeServerProvider: ActiveServerProvider by inject()
 
@@ -43,13 +42,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
         withContext(Dispatchers.IO) {
             if (!ActiveServerProvider.isOffline(context)) {
                 val musicService = MusicServiceFactory.getMusicService(context)
-                try {
-                    musicFolders.postValue(musicService.getMusicFolders(refresh, context))
-                } catch (exception: Exception) {
-                    Handler(Looper.getMainLooper()).post {
-                        CommunicationErrorHandler.handleError(exception, context)
-                    }
-                }
+                musicFolders.postValue(musicService.getMusicFolders(refresh, context))
             }
         }
     }
@@ -286,7 +279,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    suspend fun getShare(shareId: String, shareName: CharSequence?) {
+    suspend fun getShare(shareId: String) {
 
         withContext(Dispatchers.IO) {
             if (!ActiveServerProvider.isOffline(context)) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ServerSettingsModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ServerSettingsModel.kt
@@ -1,9 +1,9 @@
 package org.moire.ultrasonic.fragment
 
-import android.content.Context
+import android.app.Application
 import android.content.SharedPreferences
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.CoroutineScope
@@ -22,8 +22,8 @@ import timber.log.Timber
 class ServerSettingsModel(
     private val repository: ServerSettingDao,
     private val activeServerProvider: ActiveServerProvider,
-    private val context: Context
-) : ViewModel() {
+    application: Application
+) : AndroidViewModel(application) {
 
     companion object {
         private const val PREFERENCES_KEY_SERVER_MIGRATED = "serverMigrated"
@@ -54,6 +54,7 @@ class ServerSettingsModel(
             if (rowCount == null || rowCount == 0) {
                 // First time load up the server settings from the Preferences
                 val dbServerList = mutableListOf<ServerSetting>()
+                val context = getApplication<Application>().applicationContext
                 val settings = PreferenceManager.getDefaultSharedPreferences(context)
                 val serverNum = settings.getInt(PREFERENCES_KEY_ACTIVE_SERVERS, 0)
 


### PR DESCRIPTION
This continues the work started in #410

The custom class `LoadTask` has been replaced with Kotlin coroutines. Code that take care of the UI stayed in the Fragment and all the code that does the loading went into SelectAlbumModel

There is one minor functional change:
I made the long tap on an Album open the context menu, even if the name of the Album was longer than others.

