### PR TITLE
Get rid of rogue session

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
@@ -492,13 +492,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
     }
 
     private void setMediaButtonsEnabled(boolean enabled) {
-        if (enabled) {
-            lockScreenEnabled.setEnabled(true);
-            Util.registerMediaButtonEventReceiver(getActivity(), false);
-        } else {
-            lockScreenEnabled.setEnabled(false);
-            Util.unregisterMediaButtonEventReceiver(getActivity(), false);
-        }
+        lockScreenEnabled.setEnabled(enabled);
+        Util.updateMediaButtonEventReceiver();
     }
 
     private void setBluetoothPreferences(boolean enabled) {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/BluetoothIntentReceiver.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/BluetoothIntentReceiver.java
@@ -29,7 +29,7 @@ import org.moire.ultrasonic.util.Constants;
 import org.moire.ultrasonic.util.Util;
 
 /**
- * Request media button focus when connected to Bluetooth A2DP.
+ * Resume or pause playback on Bluetooth A2DP connect/disconnect.
  *
  * @author Sindre Mehus
  */
@@ -63,7 +63,6 @@ public class BluetoothIntentReceiver extends BroadcastReceiver
 		if (state == android.bluetooth.BluetoothA2dp.STATE_CONNECTED) actionA2dpConnected = true;
 		else if (state == android.bluetooth.BluetoothA2dp.STATE_DISCONNECTED) actionA2dpDisconnected = true;
 
-		boolean connected = actionA2dpConnected || actionBluetoothDeviceConnected;
 		boolean resume = false;
 		boolean pause = false;
 
@@ -81,12 +80,6 @@ public class BluetoothIntentReceiver extends BroadcastReceiver
 				break;
 			case Constants.PREFERENCE_VALUE_A2DP: pause = actionA2dpDisconnected;
 				break;
-		}
-
-		if (connected)
-		{
-			Timber.i("Connected to Bluetooth device %s address %s, requesting media button focus.", name, address);
-			Util.registerMediaButtonEventReceiver(context, false);
 		}
 
 		if (resume)

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/MediaButtonIntentReceiver.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/MediaButtonIntentReceiver.java
@@ -46,7 +46,7 @@ public class MediaButtonIntentReceiver extends BroadcastReceiver
 		String intentAction = intent.getAction();
 
 		// If media button are turned off and we received a media button, exit
-		if (!Util.getMediaButtonsPreference(context) &&
+		if (!Util.getMediaButtonsEnabled(context) &&
 				Intent.ACTION_MEDIA_BUTTON.equals(intentAction)) return;
 
 		// Only process media buttons and CMD_PROCESS_KEYCODE, which is received from the widgets

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
@@ -76,9 +76,6 @@ public class MediaPlayerLifecycleSupport
 
 		registerHeadsetReceiver();
 
-		// React to media buttons.
-		Util.registerMediaButtonEventReceiver(context, true);
-
 		mediaPlayerController.onCreate();
 		if (autoPlay) mediaPlayerController.preload();
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -679,7 +679,7 @@ public class Util
 
 	public static void registerMediaButtonEventReceiver(Context context, boolean isService)
 	{
-		if (getMediaButtonsPreference(context))
+		if (getMediaButtonsEnabled(context))
 		{
 			if (isService) mediaButtonsRegisteredForService = true;
 			else mediaButtonsRegisteredForUI = true;
@@ -1064,7 +1064,7 @@ public class Util
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_INCREMENT_TIME, "5"));
 	}
 
-	public static boolean getMediaButtonsPreference(Context context)
+	public static boolean getMediaButtonsEnabled(Context context)
 	{
 		SharedPreferences preferences = getPreferences(context);
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_MEDIA_BUTTONS, true);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -31,7 +31,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.media.AudioManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
@@ -53,8 +52,8 @@ import org.moire.ultrasonic.R;
 import org.moire.ultrasonic.data.ActiveServerProvider;
 import org.moire.ultrasonic.domain.*;
 import org.moire.ultrasonic.domain.MusicDirectory.Entry;
-import org.moire.ultrasonic.receiver.MediaButtonIntentReceiver;
 import org.moire.ultrasonic.service.DownloadFile;
+import org.moire.ultrasonic.service.MediaPlayerService;
 
 import java.io.*;
 import java.security.MessageDigest;
@@ -685,8 +684,13 @@ public class Util
 			if (isService) mediaButtonsRegisteredForService = true;
 			else mediaButtonsRegisteredForUI = true;
 
-			AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-			audioManager.registerMediaButtonEventReceiver(new ComponentName(context.getPackageName(), MediaButtonIntentReceiver.class.getName()));
+			MediaPlayerService.executeOnStartedMediaPlayerService(context, (mediaPlayerService) ->
+					{
+						mediaPlayerService.registerMediaButtonEventReceiver();
+						return null;
+					}
+			);
+
 		}
 	}
 
@@ -698,8 +702,13 @@ public class Util
 		// Do not unregister while there is an active part of the app which needs the control
 		if (mediaButtonsRegisteredForService || mediaButtonsRegisteredForUI) return;
 
-		AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-		audioManager.unregisterMediaButtonEventReceiver(new ComponentName(context.getPackageName(), MediaButtonIntentReceiver.class.getName()));
+		MediaPlayerService.executeOnStartedMediaPlayerService(context, (mediaPlayerService) ->
+				{
+					mediaPlayerService.unregisterMediaButtonEventReceiver();
+					return null;
+				}
+		);
+
 		Timber.i("MediaButtonEventReceiver unregistered.");
 	}
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -677,39 +677,14 @@ public class Util
 		return Bitmap.createScaledBitmap(bitmap, size, getScaledHeight(bitmap, size), true);
 	}
 
-	public static void registerMediaButtonEventReceiver(Context context, boolean isService)
+	// Trigger an update on the MediaSession. Depending on the preference it will register
+	// or deregister the MediaButtonReceiver.
+	public static void updateMediaButtonEventReceiver()
 	{
-		if (getMediaButtonsEnabled(context))
-		{
-			if (isService) mediaButtonsRegisteredForService = true;
-			else mediaButtonsRegisteredForUI = true;
-
-			MediaPlayerService.executeOnStartedMediaPlayerService(context, (mediaPlayerService) ->
-					{
-						mediaPlayerService.registerMediaButtonEventReceiver();
-						return null;
-					}
-			);
-
+		MediaPlayerService mediaPlayerService = MediaPlayerService.getRunningInstance();
+		if (mediaPlayerService != null) {
+			mediaPlayerService.updateMediaButtonReceiver();
 		}
-	}
-
-	public static void unregisterMediaButtonEventReceiver(Context context, boolean isService)
-	{
-		if (isService) mediaButtonsRegisteredForService = false;
-		else mediaButtonsRegisteredForUI = false;
-
-		// Do not unregister while there is an active part of the app which needs the control
-		if (mediaButtonsRegisteredForService || mediaButtonsRegisteredForUI) return;
-
-		MediaPlayerService.executeOnStartedMediaPlayerService(context, (mediaPlayerService) ->
-				{
-					mediaPlayerService.unregisterMediaButtonEventReceiver();
-					return null;
-				}
-		);
-
-		Timber.i("MediaButtonEventReceiver unregistered.");
 	}
 
 	public static MusicDirectory getSongsFromSearchResult(SearchResult searchResult)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
@@ -178,7 +178,7 @@ class NavigationActivity : AppCompatActivity() {
         super.onResume()
 
         setMenuForServerSetting()
-        Util.registerMediaButtonEventReceiver(this, false)
+
         // Lifecycle support's constructor registers some event receivers so it should be created early
         lifecycleSupport.onCreate()
 
@@ -188,7 +188,6 @@ class NavigationActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        Util.unregisterMediaButtonEventReceiver(this, false)
         nowPlayingEventDistributor.unsubscribe(nowPlayingEventListener)
         themeChangedEventDistributor.unsubscribe(themeChangedEventListener)
         imageLoaderProvider.clearImageLoader()
@@ -310,7 +309,6 @@ class NavigationActivity : AppCompatActivity() {
 
     private fun exit() {
         lifecycleSupport.onDestroy()
-        Util.unregisterMediaButtonEventReceiver(this, false)
         finish()
     }
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
@@ -119,7 +119,6 @@ class LocalMediaPlayer(
         }.start()
 
         wakeLock.setReferenceCounted(false)
-        Util.registerMediaButtonEventReceiver(context, true)
         Timber.i("LocalMediaPlayer created")
     }
 
@@ -146,7 +145,7 @@ class LocalMediaPlayer(
             if (nextPlayingTask != null) {
                 nextPlayingTask!!.cancel()
             }
-            Util.unregisterMediaButtonEventReceiver(context, true)
+
             wakeLock.release()
         } catch (exception: Throwable) {
             Timber.w(exception, "LocalMediaPlayer onDestroy exception: ")

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
@@ -869,10 +869,13 @@ class MediaPlayerService : Service() {
                 synchronized(instanceLock) { return instance }
             }
 
+
+
+
         @JvmStatic
         fun executeOnStartedMediaPlayerService(
             context: Context,
-            taskToExecute: Consumer<MediaPlayerService?>
+            taskToExecute: (MediaPlayerService?) -> Unit
         ) {
 
             val t: Thread = object : Thread() {
@@ -882,7 +885,7 @@ class MediaPlayerService : Service() {
                         Timber.e("ExecuteOnStarted.. failed to get a MediaPlayerService instance!")
                         return
                     }
-                    taskToExecute.accept(instance)
+                    taskToExecute(instance)
                 }
             }
             t.start()

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
@@ -12,6 +12,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -22,7 +23,6 @@ import android.support.v4.media.session.PlaybackStateCompat
 import android.view.KeyEvent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import java.util.ArrayList
 import org.koin.android.ext.android.inject
 import org.moire.ultrasonic.R
 import org.moire.ultrasonic.activity.NavigationActivity
@@ -33,6 +33,7 @@ import org.moire.ultrasonic.provider.UltrasonicAppWidgetProvider4X1
 import org.moire.ultrasonic.provider.UltrasonicAppWidgetProvider4X2
 import org.moire.ultrasonic.provider.UltrasonicAppWidgetProvider4X3
 import org.moire.ultrasonic.provider.UltrasonicAppWidgetProvider4X4
+import org.moire.ultrasonic.receiver.MediaButtonIntentReceiver
 import org.moire.ultrasonic.service.MusicServiceFactory.getMusicService
 import org.moire.ultrasonic.util.Constants
 import org.moire.ultrasonic.util.FileUtil
@@ -838,10 +839,31 @@ class MediaPlayerService : Service() {
         )
     }
 
+    fun registerMediaButtonEventReceiver() {
+        val component = ComponentName(packageName, MediaButtonIntentReceiver::class.java.name)
+        val mediaButtonIntent = Intent(Intent.ACTION_MEDIA_BUTTON)
+        mediaButtonIntent.component = component
+
+        val pendingIntent = PendingIntent.getBroadcast(
+            this,
+            INTENT_CODE_MEDIA_BUTTON,
+            mediaButtonIntent,
+            PendingIntent.FLAG_CANCEL_CURRENT
+        )
+
+        mediaSession?.setMediaButtonReceiver(pendingIntent)
+    }
+
+    fun unregisterMediaButtonEventReceiver() {
+        mediaSession?.setMediaButtonReceiver(null)
+    }
+
     companion object {
         private const val NOTIFICATION_CHANNEL_ID = "org.moire.ultrasonic"
         private const val NOTIFICATION_CHANNEL_NAME = "Ultrasonic background service"
         private const val NOTIFICATION_ID = 3033
+        private const val INTENT_CODE_MEDIA_BUTTON = 161
+
         private var instance: MediaPlayerService? = null
         private val instanceLock = Any()
 
@@ -868,9 +890,6 @@ class MediaPlayerService : Service() {
             get() {
                 synchronized(instanceLock) { return instance }
             }
-
-
-
 
         @JvmStatic
         fun executeOnStartedMediaPlayerService(

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
@@ -793,7 +793,8 @@ class MediaPlayerService : Service() {
 
         mediaSession = MediaSessionCompat(applicationContext, "UltrasonicService")
         mediaSessionToken = mediaSession!!.sessionToken
-        // mediaController = new MediaControllerCompat(getApplicationContext(), mediaSessionToken);
+
+        updateMediaButtonReceiver()
 
         mediaSession!!.setCallback(object : MediaSessionCompat.Callback() {
             override fun onPlay() {
@@ -837,6 +838,14 @@ class MediaPlayerService : Service() {
             }
         }
         )
+    }
+
+    fun updateMediaButtonReceiver() {
+        if (Util.getMediaButtonsEnabled(applicationContext)) {
+            registerMediaButtonEventReceiver()
+        } else {
+            unregisterMediaButtonEventReceiver()
+        }
     }
 
     fun registerMediaButtonEventReceiver() {


### PR DESCRIPTION
Using [Media Controller Tester](https://developer.android.com/guide/topics/media-apps/audio-app/media-controller-test) I finally figured out that there was an empty media session being created on start.

It took quite some time to figure out where it was coming from, but now it should be gone.

@nitehu Can you test this?