### PR TITLE
Add Ampache as supported server

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ See [CONTRIBUTING](CONTRIBUTING.md).
 - [Subsonic](http://www.subsonic.org/pages/index.jsp)
 - [Airsonic](https://github.com/airsonic/airsonic)
 - [Supysonic](https://github.com/spl0k/supysonic)
+- [Ampache](https://ampache.org/)
 
 Other *Subsonic API* implementations should work as well as long as they follow API
 [documentation](http://www.subsonic.org/pages/api.jsp).


### PR DESCRIPTION
I'd like to add Ampache as a supported and tested server to the readme.
I use it for a year now and Ultrasonic works very well with it. Also their lead, lachlan is usually a great help to us providing issues and fixing Ampache when we find something.