### PR TITLE
Make all preference operations context-free

### DIFF
--- a/detekt-baseline-debug.xml
+++ b/detekt-baseline-debug.xml
@@ -21,23 +21,9 @@
     <ID>CommentOverPrivateFunction:ServerSettingsModel.kt$ServerSettingsModel$ private suspend fun areIndexesMissing(): Boolean</ID>
     <ID>CommentOverPrivateFunction:ServerSettingsModel.kt$ServerSettingsModel$ private suspend fun reindexSettings()</ID>
     <ID>ComplexCondition:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$!append &amp;&amp; !playNext &amp;&amp; !unpin &amp;&amp; !background</ID>
-    <ID>ComplexCondition:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$!isOffline(activity) &amp;&amp; isArtist &amp;&amp; Util.getShouldUseId3Tags(activity)</ID>
-    <ID>ComplexCondition:EditServerFragment.kt$EditServerFragment$urlString != urlString.trim(' ') || urlString.contains("@") || url.host.isNullOrBlank()</ID>
     <ID>ComplexCondition:FilePickerAdapter.kt$FilePickerAdapter$currentDirectory.absolutePath == "/" || currentDirectory.absolutePath == "/storage" || currentDirectory.absolutePath == "/storage/emulated" || currentDirectory.absolutePath == "/mnt"</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer$Util.getGaplessPlaybackPreference(context) &amp;&amp; Build.VERSION.SDK_INT &gt;= Build.VERSION_CODES.JELLY_BEAN &amp;&amp; ( playerState === PlayerState.STARTED || playerState === PlayerState.PAUSED )</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer$playerState !== PlayerState.IDLE &amp;&amp; playerState !== PlayerState.DOWNLOADING &amp;&amp; playerState !== PlayerState.PREPARING</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer.&lt;no name provided&gt;$!isPartial || downloadFile.isWorkDone &amp;&amp; abs(duration - pos) &lt; 1000</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer.&lt;no name provided&gt;$Util.getGaplessPlaybackPreference(context) &amp;&amp; nextPlaying != null &amp;&amp; nextPlayerState === PlayerState.PREPARED</ID>
-    <ID>ComplexCondition:MediaPlayerService.kt$MediaPlayerService$localMediaPlayer.playerState === PlayerState.IDLE || localMediaPlayer.playerState === PlayerState.DOWNLOADING || localMediaPlayer.playerState === PlayerState.PREPARING</ID>
-    <ID>ComplexCondition:MediaPlayerService.kt$MediaPlayerService$localMediaPlayer.playerState === PlayerState.PAUSED || localMediaPlayer.playerState === PlayerState.COMPLETED || localMediaPlayer.playerState === PlayerState.STOPPED</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !deleteEnabled &amp;&amp; !isOffline(context)</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !isOffline(context) &amp;&amp; selection.size &gt; pinnedCount</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$entry != null &amp;&amp; !entry.isDirectory &amp;&amp; !entry.isVideo</ID>
-    <ID>ComplexCondition:SelectAlbumModel.kt$SelectAlbumModel$Util.getShouldShowAllSongsByArtist(context) &amp;&amp; musicDirectory.findChild(allSongsId) == null &amp;&amp; musicDirectory.getChildren(true, false).size == musicDirectory.getChildren(true, true).size</ID>
-    <ID>ComplexCondition:ServerSettingsModel.kt$ServerSettingsModel$url.isNullOrEmpty() || userName.isNullOrEmpty() || isMigrated</ID>
-    <ID>ComplexCondition:SongView.kt$SongView$TextUtils.isEmpty(transcodedSuffix) || transcodedSuffix == suffix || song.isVideo &amp;&amp; Util.getVideoPlayerType(this.context) !== VideoPlayerType.FLASH</ID>
-    <ID>ComplexCondition:SubsonicImageLoaderProxy.kt$SubsonicImageLoaderProxy$id != null &amp;&amp; view != null &amp;&amp; view is ImageView</ID>
-    <ID>ComplexCondition:SubsonicImageLoaderProxy.kt$SubsonicImageLoaderProxy$username != null &amp;&amp; view != null &amp;&amp; view is ImageView</ID>
+    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer$Util.getGaplessPlaybackPreference() &amp;&amp; Build.VERSION.SDK_INT &gt;= Build.VERSION_CODES.JELLY_BEAN &amp;&amp; ( playerState === PlayerState.STARTED || playerState === PlayerState.PAUSED )</ID>
+    <ID>ComplexCondition:SongView.kt$SongView$TextUtils.isEmpty(transcodedSuffix) || transcodedSuffix == suffix || song.isVideo &amp;&amp; Util.getVideoPlayerType() !== VideoPlayerType.FLASH</ID>
     <ID>ComplexMethod:CommunicationErrorHandler.kt$CommunicationErrorHandler.Companion$fun getErrorMessage(error: Throwable, context: Context): String</ID>
     <ID>ComplexMethod:DownloadFile.kt$DownloadFile.DownloadTask$override fun execute()</ID>
     <ID>ComplexMethod:EditServerFragment.kt$EditServerFragment$ private fun areFieldsChanged(): Boolean</ID>
@@ -96,7 +82,6 @@
     <ID>LongMethod:DownloadFile.kt$DownloadFile$private fun updateModificationDate(file: File)</ID>
     <ID>LongMethod:DownloadFile.kt$DownloadFile.DownloadTask$override fun execute()</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler$fun download( fragment: Fragment, append: Boolean, save: Boolean, autoPlay: Boolean, playNext: Boolean, shuffle: Boolean, songs: List&lt;MusicDirectory.Entry?&gt; )</ID>
-    <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$@Throws(Exception::class) private fun getSongsForArtist( id: String, songs: MutableCollection&lt;MusicDirectory.Entry&gt; )</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$@Throws(Exception::class) private fun getSongsRecursively( parent: MusicDirectory, songs: MutableList&lt;MusicDirectory.Entry&gt; )</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$@Throws(Throwable::class) override fun doInBackground(): List&lt;MusicDirectory.Entry&gt;</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$override fun done(songs: List&lt;MusicDirectory.Entry&gt;)</ID>
@@ -129,7 +114,6 @@
     <ID>LongMethod:MediaPlayerService.kt$MediaPlayerService$private fun setupOnPlayerStateChangedHandler()</ID>
     <ID>LongMethod:MediaPlayerService.kt$MediaPlayerService$private fun setupOnSongCompletedHandler()</ID>
     <ID>LongMethod:MediaPlayerService.kt$MediaPlayerService$private fun updateMediaSession(currentPlaying: DownloadFile?, playerState: PlayerState)</ID>
-    <ID>LongMethod:MediaStoreService.kt$MediaStoreService$fun saveInMediaStore(downloadFile: DownloadFile)</ID>
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$// TODO Test if this works with external Intents // android.intent.action.SEARCH and android.media.action.MEDIA_PLAY_FROM_SEARCH calls here override fun onNewIntent(intent: Intent?)</ID>
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$private fun showNowPlaying()</ID>

--- a/detekt-baseline-debug.xml
+++ b/detekt-baseline-debug.xml
@@ -119,7 +119,7 @@
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$private fun showNowPlaying()</ID>
     <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(Exception::class) override fun getAvatar( context: Context, username: String?, size: Int, saveToFile: Boolean, highQuality: Boolean ): Bitmap?</ID>
     <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(Exception::class) override fun getCoverArt( context: Context, entry: MusicDirectory.Entry?, size: Int, saveToFile: Boolean, highQuality: Boolean ): Bitmap?</ID>
-    <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(IOException::class) private fun savePlaylist( name: String?, context: Context, playlist: MusicDirectory )</ID>
+    <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(IOException::class) private fun savePlaylist( name: String?, playlist: MusicDirectory )</ID>
     <ID>LongMethod:RestErrorMapper.kt$ fun SubsonicRESTException.getLocalizedErrorMessage(context: Context): String</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onContextItemSelected(menuItem: MenuItem): Boolean</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>

--- a/detekt-baseline-main.xml
+++ b/detekt-baseline-main.xml
@@ -2,7 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ComplexCondition:SubsonicAPIClient.kt$SubsonicAPIClient$contentType != null &amp;&amp; contentType.type().equals("application", true) &amp;&amp; contentType.subtype().equals("json", true)</ID>
     <ID>ComplexMethod:AlbumListType.kt$AlbumListType.Companion$@JvmStatic fun fromName(typeName: String): AlbumListType</ID>
     <ID>ComplexMethod:SubsonicAPIVersions.kt$SubsonicAPIVersions.Companion$@JvmStatic @Throws(IllegalArgumentException::class) fun getClosestKnownClientApiVersion(apiVersion: String): SubsonicAPIVersions</ID>
     <ID>ComplexMethod:SubsonicError.kt$SubsonicError.Companion$fun getError(code: Int, message: String)</ID>

--- a/detekt-baseline-release.xml
+++ b/detekt-baseline-release.xml
@@ -21,23 +21,9 @@
     <ID>CommentOverPrivateFunction:ServerSettingsModel.kt$ServerSettingsModel$ private suspend fun areIndexesMissing(): Boolean</ID>
     <ID>CommentOverPrivateFunction:ServerSettingsModel.kt$ServerSettingsModel$ private suspend fun reindexSettings()</ID>
     <ID>ComplexCondition:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$!append &amp;&amp; !playNext &amp;&amp; !unpin &amp;&amp; !background</ID>
-    <ID>ComplexCondition:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$!isOffline(activity) &amp;&amp; isArtist &amp;&amp; Util.getShouldUseId3Tags(activity)</ID>
-    <ID>ComplexCondition:EditServerFragment.kt$EditServerFragment$urlString != urlString.trim(' ') || urlString.contains("@") || url.host.isNullOrBlank()</ID>
     <ID>ComplexCondition:FilePickerAdapter.kt$FilePickerAdapter$currentDirectory.absolutePath == "/" || currentDirectory.absolutePath == "/storage" || currentDirectory.absolutePath == "/storage/emulated" || currentDirectory.absolutePath == "/mnt"</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer$Util.getGaplessPlaybackPreference(context) &amp;&amp; Build.VERSION.SDK_INT &gt;= Build.VERSION_CODES.JELLY_BEAN &amp;&amp; ( playerState === PlayerState.STARTED || playerState === PlayerState.PAUSED )</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer$playerState !== PlayerState.IDLE &amp;&amp; playerState !== PlayerState.DOWNLOADING &amp;&amp; playerState !== PlayerState.PREPARING</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer.&lt;no name provided&gt;$!isPartial || downloadFile.isWorkDone &amp;&amp; abs(duration - pos) &lt; 1000</ID>
-    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer.&lt;no name provided&gt;$Util.getGaplessPlaybackPreference(context) &amp;&amp; nextPlaying != null &amp;&amp; nextPlayerState === PlayerState.PREPARED</ID>
-    <ID>ComplexCondition:MediaPlayerService.kt$MediaPlayerService$localMediaPlayer.playerState === PlayerState.IDLE || localMediaPlayer.playerState === PlayerState.DOWNLOADING || localMediaPlayer.playerState === PlayerState.PREPARING</ID>
-    <ID>ComplexCondition:MediaPlayerService.kt$MediaPlayerService$localMediaPlayer.playerState === PlayerState.PAUSED || localMediaPlayer.playerState === PlayerState.COMPLETED || localMediaPlayer.playerState === PlayerState.STOPPED</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !deleteEnabled &amp;&amp; !isOffline(context)</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$enabled &amp;&amp; !isOffline(context) &amp;&amp; selection.size &gt; pinnedCount</ID>
-    <ID>ComplexCondition:SelectAlbumFragment.kt$SelectAlbumFragment$entry != null &amp;&amp; !entry.isDirectory &amp;&amp; !entry.isVideo</ID>
-    <ID>ComplexCondition:SelectAlbumModel.kt$SelectAlbumModel$Util.getShouldShowAllSongsByArtist(context) &amp;&amp; musicDirectory.findChild(allSongsId) == null &amp;&amp; musicDirectory.getChildren(true, false).size == musicDirectory.getChildren(true, true).size</ID>
-    <ID>ComplexCondition:ServerSettingsModel.kt$ServerSettingsModel$url.isNullOrEmpty() || userName.isNullOrEmpty() || isMigrated</ID>
-    <ID>ComplexCondition:SongView.kt$SongView$TextUtils.isEmpty(transcodedSuffix) || transcodedSuffix == suffix || song.isVideo &amp;&amp; Util.getVideoPlayerType(this.context) !== VideoPlayerType.FLASH</ID>
-    <ID>ComplexCondition:SubsonicImageLoaderProxy.kt$SubsonicImageLoaderProxy$id != null &amp;&amp; view != null &amp;&amp; view is ImageView</ID>
-    <ID>ComplexCondition:SubsonicImageLoaderProxy.kt$SubsonicImageLoaderProxy$username != null &amp;&amp; view != null &amp;&amp; view is ImageView</ID>
+    <ID>ComplexCondition:LocalMediaPlayer.kt$LocalMediaPlayer$Util.getGaplessPlaybackPreference() &amp;&amp; Build.VERSION.SDK_INT &gt;= Build.VERSION_CODES.JELLY_BEAN &amp;&amp; ( playerState === PlayerState.STARTED || playerState === PlayerState.PAUSED )</ID>
+    <ID>ComplexCondition:SongView.kt$SongView$TextUtils.isEmpty(transcodedSuffix) || transcodedSuffix == suffix || song.isVideo &amp;&amp; Util.getVideoPlayerType() !== VideoPlayerType.FLASH</ID>
     <ID>ComplexMethod:CommunicationErrorHandler.kt$CommunicationErrorHandler.Companion$fun getErrorMessage(error: Throwable, context: Context): String</ID>
     <ID>ComplexMethod:DownloadFile.kt$DownloadFile.DownloadTask$override fun execute()</ID>
     <ID>ComplexMethod:EditServerFragment.kt$EditServerFragment$ private fun areFieldsChanged(): Boolean</ID>
@@ -52,8 +38,6 @@
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun enableButtons()</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateDisplay(refresh: Boolean)</ID>
     <ID>ComplexMethod:SelectAlbumFragment.kt$SelectAlbumFragment$private fun updateInterfaceWithEntries(musicDirectory: MusicDirectory)</ID>
-    <ID>ComplexMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getAlbumList(albumListType: String, size: Int, offset: Int)</ID>
-    <ID>ComplexMethod:SelectAlbumModel.kt$SelectAlbumModel$suspend fun getMusicDirectory( refresh: Boolean, id: String?, name: String?, parentId: String? )</ID>
     <ID>ComplexMethod:SelectArtistFragment.kt$SelectArtistFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:ServerRowAdapter.kt$ServerRowAdapter$ override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View?</ID>
     <ID>ComplexMethod:SongView.kt$SongView$fun setSong(song: MusicDirectory.Entry, checkable: Boolean, draggable: Boolean)</ID>
@@ -98,7 +82,6 @@
     <ID>LongMethod:DownloadFile.kt$DownloadFile$private fun updateModificationDate(file: File)</ID>
     <ID>LongMethod:DownloadFile.kt$DownloadFile.DownloadTask$override fun execute()</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler$fun download( fragment: Fragment, append: Boolean, save: Boolean, autoPlay: Boolean, playNext: Boolean, shuffle: Boolean, songs: List&lt;MusicDirectory.Entry?&gt; )</ID>
-    <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$@Throws(Exception::class) private fun getSongsForArtist( id: String, songs: MutableCollection&lt;MusicDirectory.Entry&gt; )</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$@Throws(Exception::class) private fun getSongsRecursively( parent: MusicDirectory, songs: MutableList&lt;MusicDirectory.Entry&gt; )</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$@Throws(Throwable::class) override fun doInBackground(): List&lt;MusicDirectory.Entry&gt;</ID>
     <ID>LongMethod:DownloadHandler.kt$DownloadHandler.&lt;no name provided&gt;$override fun done(songs: List&lt;MusicDirectory.Entry&gt;)</ID>
@@ -131,7 +114,6 @@
     <ID>LongMethod:MediaPlayerService.kt$MediaPlayerService$private fun setupOnPlayerStateChangedHandler()</ID>
     <ID>LongMethod:MediaPlayerService.kt$MediaPlayerService$private fun setupOnSongCompletedHandler()</ID>
     <ID>LongMethod:MediaPlayerService.kt$MediaPlayerService$private fun updateMediaSession(currentPlaying: DownloadFile?, playerState: PlayerState)</ID>
-    <ID>LongMethod:MediaStoreService.kt$MediaStoreService$fun saveInMediaStore(downloadFile: DownloadFile)</ID>
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$// TODO Test if this works with external Intents // android.intent.action.SEARCH and android.media.action.MEDIA_PLAY_FROM_SEARCH calls here override fun onNewIntent(intent: Intent?)</ID>
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$private fun showNowPlaying()</ID>

--- a/detekt-baseline-release.xml
+++ b/detekt-baseline-release.xml
@@ -119,7 +119,7 @@
     <ID>LongMethod:NavigationActivity.kt$NavigationActivity$private fun showNowPlaying()</ID>
     <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(Exception::class) override fun getAvatar( context: Context, username: String?, size: Int, saveToFile: Boolean, highQuality: Boolean ): Bitmap?</ID>
     <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(Exception::class) override fun getCoverArt( context: Context, entry: MusicDirectory.Entry?, size: Int, saveToFile: Boolean, highQuality: Boolean ): Bitmap?</ID>
-    <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(IOException::class) private fun savePlaylist( name: String?, context: Context, playlist: MusicDirectory )</ID>
+    <ID>LongMethod:RESTMusicService.kt$RESTMusicService$@Throws(IOException::class) private fun savePlaylist( name: String?, playlist: MusicDirectory )</ID>
     <ID>LongMethod:RestErrorMapper.kt$ fun SubsonicRESTException.getLocalizedErrorMessage(context: Context): String</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onContextItemSelected(menuItem: MenuItem): Boolean</ID>
     <ID>LongMethod:SelectAlbumFragment.kt$SelectAlbumFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
@@ -383,7 +383,7 @@ public class BookmarksFragment extends Fragment {
         {
             MusicService musicService = MusicServiceFactory.getMusicService(getContext());
             MusicDirectory dir = load(musicService);
-            boolean valid = musicService.isLicenseValid(getContext());
+            boolean valid = musicService.isLicenseValid();
             return new Pair<>(dir, valid);
         }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
@@ -381,7 +381,7 @@ public class BookmarksFragment extends Fragment {
         @Override
         protected Pair<MusicDirectory, Boolean> doInBackground() throws Throwable
         {
-            MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+            MusicService musicService = MusicServiceFactory.getMusicService();
             MusicDirectory dir = load(musicService);
             boolean valid = musicService.isLicenseValid();
             return new Pair<>(dir, valid);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/BookmarksFragment.java
@@ -306,9 +306,9 @@ public class BookmarksFragment extends Fragment {
         }
 
         playNowButton.setVisibility(enabled && deleteEnabled ? View.VISIBLE : View.GONE);
-        pinButton.setVisibility((enabled && !ActiveServerProvider.Companion.isOffline(getContext()) && selection.size() > pinnedCount) ? View.VISIBLE : View.GONE);
+        pinButton.setVisibility((enabled && !ActiveServerProvider.Companion.isOffline() && selection.size() > pinnedCount) ? View.VISIBLE : View.GONE);
         unpinButton.setVisibility(enabled && unpinEnabled ? View.VISIBLE : View.GONE);
-        downloadButton.setVisibility(enabled && !deleteEnabled && !ActiveServerProvider.Companion.isOffline(getContext()) ? View.VISIBLE : View.GONE);
+        downloadButton.setVisibility(enabled && !deleteEnabled && !ActiveServerProvider.Companion.isOffline() ? View.VISIBLE : View.GONE);
         deleteButton.setVisibility(enabled && deleteEnabled ? View.VISIBLE : View.GONE);
     }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/ChatFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/ChatFragment.java
@@ -202,7 +202,7 @@ public class ChatFragment extends Fragment {
 
     private void timerMethod()
     {
-        int refreshInterval = Util.getChatRefreshInterval(getContext());
+        int refreshInterval = Util.getChatRefreshInterval();
 
         if (refreshInterval > 0)
         {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/ChatFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/ChatFragment.java
@@ -249,7 +249,7 @@ public class ChatFragment extends Fragment {
                     @Override
                     protected Void doInBackground() throws Throwable
                     {
-                        MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                        MusicService musicService = MusicServiceFactory.getMusicService();
                         musicService.addChatMessage(message, getContext());
                         return null;
                     }
@@ -273,7 +273,7 @@ public class ChatFragment extends Fragment {
             @Override
             protected List<ChatMessage> doInBackground() throws Throwable
             {
-                MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                MusicService musicService = MusicServiceFactory.getMusicService();
                 return musicService.getChatMessages(lastChatMessageTime, getContext());
             }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/LyricsFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/LyricsFragment.java
@@ -78,7 +78,7 @@ public class LyricsFragment extends Fragment {
                 if (arguments == null) return null;
                 String artist = arguments.getString(Constants.INTENT_EXTRA_NAME_ARTIST);
                 String title = arguments.getString(Constants.INTENT_EXTRA_NAME_TITLE);
-                MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                MusicService musicService = MusicServiceFactory.getMusicService();
                 return musicService.getLyrics(artist, title, getContext());
             }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/MainFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/MainFragment.java
@@ -65,7 +65,7 @@ public class MainFragment extends Fragment {
         super.onResume();
         boolean shouldRestart = false;
 
-        boolean id3 = Util.getShouldUseId3Tags(MainFragment.this.getContext());
+        boolean id3 = Util.getShouldUseId3Tags();
         String currentActiveServerProperties = getActiveServerProperties();
 
         if (id3 != shouldUseId3)
@@ -126,7 +126,7 @@ public class MainFragment extends Fragment {
             adapter.addViews(asList(randomSongsButton, songsStarredButton), true);
             adapter.addView(albumsTitle, false);
 
-            if (Util.getShouldUseId3Tags(MainFragment.this.getContext()))
+            if (Util.getShouldUseId3Tags())
             {
                 shouldUseId3 = true;
                 adapter.addViews(asList(albumsNewestButton, albumsRecentButton, albumsFrequentButton, albumsRandomButton, albumsStarredButton, albumsAlphaByNameButton, albumsAlphaByArtistButton), true);
@@ -224,7 +224,7 @@ public class MainFragment extends Fragment {
         Bundle bundle = new Bundle();
         bundle.putString(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_TYPE, type);
         bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_TITLE, title);
-        bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_SIZE, Util.getMaxAlbums(getContext()));
+        bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_SIZE, Util.getMaxAlbums());
         bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_OFFSET, 0);
         Navigation.findNavController(getView()).navigate(R.id.mainToSelectAlbum, bundle);
     }
@@ -240,7 +240,7 @@ public class MainFragment extends Fragment {
     {
         Bundle bundle = new Bundle();
         bundle.putInt(Constants.INTENT_EXTRA_NAME_RANDOM, 1);
-        bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_SIZE, Util.getMaxSongs(getContext()));
+        bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_SIZE, Util.getMaxSongs());
         Navigation.findNavController(getView()).navigate(R.id.mainToSelectAlbum, bundle);
     }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/MainFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/MainFragment.java
@@ -118,7 +118,7 @@ public class MainFragment extends Fragment {
         final MergeAdapter adapter = new MergeAdapter();
         adapter.addViews(Collections.singletonList(serverButton), true);
 
-        if (!ActiveServerProvider.Companion.isOffline(this.getContext()))
+        if (!ActiveServerProvider.Companion.isOffline())
         {
             adapter.addView(musicTitle, false);
             adapter.addViews(asList(artistsButton, albumsButton, genresButton), true);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/NowPlayingFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/NowPlayingFragment.java
@@ -115,7 +115,7 @@ public class NowPlayingFragment extends Fragment {
                 nowPlayingAlbumArtImage.setOnClickListener(v -> {
                     Bundle bundle = new Bundle();
 
-                    if (Util.getShouldUseId3Tags(getContext())) {
+                    if (Util.getShouldUseId3Tags()) {
                         bundle.putBoolean(Constants.INTENT_EXTRA_NAME_IS_ALBUM, true);
                         bundle.putString(Constants.INTENT_EXTRA_NAME_ID, song.getAlbumId());
                     } else {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
@@ -709,7 +709,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
         MenuItem bookmarkRemoveMenuItem = menu.findItem(R.id.menu_item_bookmark_delete);
 
 
-        if (ActiveServerProvider.Companion.isOffline(getContext()))
+        if (ActiveServerProvider.Companion.isOffline())
         {
             if (shareMenuItem != null)
             {
@@ -834,7 +834,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
                 }
             }
 
-            if (ActiveServerProvider.Companion.isOffline(getContext()) || !Util.getShouldUseId3Tags())
+            if (ActiveServerProvider.Companion.isOffline() || !Util.getShouldUseId3Tags())
             {
                 MenuItem menuItem = menu.findItem(R.id.menu_show_artist);
 
@@ -844,7 +844,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
                 }
             }
 
-            if (ActiveServerProvider.Companion.isOffline(getContext()))
+            if (ActiveServerProvider.Companion.isOffline())
             {
                 MenuItem menuItem = menu.findItem(R.id.menu_lyrics);
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
@@ -287,7 +287,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
             @Override
             public void run()
             {
-                int incrementTime = Util.getIncrementTime(getActivity());
+                int incrementTime = Util.getIncrementTime();
                 changeProgress(-incrementTime);
             }
         });
@@ -326,7 +326,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
             @Override
             public void run()
             {
-                int incrementTime = Util.getIncrementTime(getActivity());
+                int incrementTime = Util.getIncrementTime();
                 changeProgress(incrementTime);
             }
         });
@@ -834,7 +834,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
                 }
             }
 
-            if (ActiveServerProvider.Companion.isOffline(getContext()) || !Util.getShouldUseId3Tags(getContext()))
+            if (ActiveServerProvider.Companion.isOffline(getContext()) || !Util.getShouldUseId3Tags())
             {
                 MenuItem menuItem = menu.findItem(R.id.menu_show_artist);
 
@@ -891,7 +891,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
                 return false;
             }
 
-            if (Util.getShouldUseId3Tags(getContext())) {
+            if (Util.getShouldUseId3Tags()) {
                 bundle = new Bundle();
                 bundle.putString(Constants.INTENT_EXTRA_NAME_ID, entry.getArtistId());
                 bundle.putString(Constants.INTENT_EXTRA_NAME_NAME, entry.getArtist());
@@ -906,7 +906,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
                 return false;
             }
 
-            String albumId = Util.getShouldUseId3Tags(getContext()) ? entry.getAlbumId() : entry.getParent();
+            String albumId = Util.getShouldUseId3Tags() ? entry.getAlbumId() : entry.getParent();
             bundle = new Bundle();
             bundle.putString(Constants.INTENT_EXTRA_NAME_ID, albumId);
             bundle.putString(Constants.INTENT_EXTRA_NAME_NAME, entry.getAlbum());

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
@@ -998,9 +998,9 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
 
                     try {
                         if (isStarred) {
-                            musicService.unstar(id, null, null, getContext());
+                            musicService.unstar(id, null, null);
                         } else {
-                            musicService.star(id, null, null, getContext());
+                            musicService.star(id, null, null);
                         }
                     } catch (Exception e) {
                         Timber.e(e);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlayerFragment.java
@@ -994,7 +994,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
             new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    final MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                    final MusicService musicService = MusicServiceFactory.getMusicService();
 
                     try {
                         if (isStarred) {
@@ -1024,7 +1024,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
             new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    final MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                    final MusicService musicService = MusicServiceFactory.getMusicService();
 
                     try {
                         musicService.createBookmark(songId, playerPosition, getContext());
@@ -1050,7 +1050,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
             new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    final MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                    final MusicService musicService = MusicServiceFactory.getMusicService();
 
                     try {
                         musicService.deleteBookmark(bookmarkSongId, getContext());
@@ -1127,7 +1127,7 @@ public class PlayerFragment extends Fragment implements GestureDetector.OnGestur
                 {
                     entries.add(downloadFile.getSong());
                 }
-                final MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                final MusicService musicService = MusicServiceFactory.getMusicService();
                 musicService.createPlaylist(null, playlistName, entries, getContext());
                 return null;
             }

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlaylistsFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlaylistsFragment.java
@@ -127,7 +127,7 @@ public class PlaylistsFragment extends Fragment {
             @Override
             protected List<Playlist> doInBackground() throws Throwable
             {
-                MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                MusicService musicService = MusicServiceFactory.getMusicService();
                 List<Playlist> playlists = musicService.getPlaylists(refresh, getContext());
 
                 if (!ActiveServerProvider.Companion.isOffline())
@@ -222,7 +222,7 @@ public class PlaylistsFragment extends Fragment {
                     @Override
                     protected Void doInBackground() throws Throwable
                     {
-                        MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                        MusicService musicService = MusicServiceFactory.getMusicService();
                         musicService.deletePlaylist(playlist.getId(), getContext());
                         return null;
                     }
@@ -312,7 +312,7 @@ public class PlaylistsFragment extends Fragment {
                         String name = nameBoxText != null ? nameBoxText.toString() : null;
                         String comment = commentBoxText != null ? commentBoxText.toString() : null;
 
-                        MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                        MusicService musicService = MusicServiceFactory.getMusicService();
                         musicService.updatePlaylist(playlist.getId(), name, comment, publicBox.isChecked(), getContext());
                         return null;
                     }

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlaylistsFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PlaylistsFragment.java
@@ -130,7 +130,7 @@ public class PlaylistsFragment extends Fragment {
                 MusicService musicService = MusicServiceFactory.getMusicService(getContext());
                 List<Playlist> playlists = musicService.getPlaylists(refresh, getContext());
 
-                if (!ActiveServerProvider.Companion.isOffline(getContext()))
+                if (!ActiveServerProvider.Companion.isOffline())
                     new CacheCleaner(getContext()).cleanPlaylists(playlists);
                 return playlists;
             }
@@ -151,14 +151,14 @@ public class PlaylistsFragment extends Fragment {
         super.onCreateContextMenu(menu, view, menuInfo);
 
         MenuInflater inflater = getActivity().getMenuInflater();
-        if (ActiveServerProvider.Companion.isOffline(getContext())) inflater.inflate(R.menu.select_playlist_context_offline, menu);
+        if (ActiveServerProvider.Companion.isOffline()) inflater.inflate(R.menu.select_playlist_context_offline, menu);
         else inflater.inflate(R.menu.select_playlist_context, menu);
 
         MenuItem downloadMenuItem = menu.findItem(R.id.album_menu_download);
 
         if (downloadMenuItem != null)
         {
-            downloadMenuItem.setVisible(!ActiveServerProvider.Companion.isOffline(getContext()));
+            downloadMenuItem.setVisible(!ActiveServerProvider.Companion.isOffline());
         }
     }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PodcastFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/PodcastFragment.java
@@ -96,7 +96,7 @@ public class PodcastFragment extends Fragment {
             @Override
             protected List<PodcastsChannel> doInBackground() throws Throwable
             {
-                MusicService musicService = MusicServiceFactory.getMusicService(context);
+                MusicService musicService = MusicServiceFactory.getMusicService();
                 return musicService.getPodcastsChannels(refresh, context);
             }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
@@ -420,7 +420,7 @@ public class SearchFragment extends Fragment {
             protected SearchResult doInBackground() throws Throwable
             {
                 SearchCriteria criteria = new SearchCriteria(query, maxArtists, maxAlbums, maxSongs);
-                MusicService service = MusicServiceFactory.getMusicService(getContext());
+                MusicService service = MusicServiceFactory.getMusicService();
                 return service.search(criteria, getContext());
             }
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
@@ -113,9 +113,9 @@ public class SearchFragment extends Fragment {
         FragmentTitle.Companion.setTitle(this, R.string.search_title);
         setHasOptionsMenu(true);
 
-        DEFAULT_ARTISTS = Util.getDefaultArtists(getContext());
-        DEFAULT_ALBUMS = Util.getDefaultAlbums(getContext());
-        DEFAULT_SONGS = Util.getDefaultSongs(getContext());
+        DEFAULT_ARTISTS = Util.getDefaultArtists();
+        DEFAULT_ALBUMS = Util.getDefaultAlbums();
+        DEFAULT_SONGS = Util.getDefaultSongs();
 
         View buttons = LayoutInflater.from(getContext()).inflate(R.layout.search_buttons, list, false);
 
@@ -410,9 +410,9 @@ public class SearchFragment extends Fragment {
 
     private void search(final String query, final boolean autoplay)
     {
-        final int maxArtists = Util.getMaxArtists(getContext());
-        final int maxAlbums = Util.getMaxAlbums(getContext());
-        final int maxSongs = Util.getMaxSongs(getContext());
+        final int maxArtists = Util.getMaxArtists();
+        final int maxAlbums = Util.getMaxAlbums();
+        final int maxSongs = Util.getMaxSongs();
 
         BackgroundTask<SearchResult> task = new FragmentBackgroundTask<SearchResult>(getActivity(), true, searchRefresh, cancellationToken)
         {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SearchFragment.java
@@ -280,10 +280,10 @@ public class SearchFragment extends Fragment {
 
         if (downloadMenuItem != null)
         {
-            downloadMenuItem.setVisible(!ActiveServerProvider.Companion.isOffline(getContext()));
+            downloadMenuItem.setVisible(!ActiveServerProvider.Companion.isOffline());
         }
 
-        if (ActiveServerProvider.Companion.isOffline(getContext()) || isArtist)
+        if (ActiveServerProvider.Companion.isOffline() || isArtist)
         {
             if (shareButton != null)
             {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SelectGenreFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SelectGenreFragment.java
@@ -108,7 +108,7 @@ public class SelectGenreFragment extends Fragment {
 
                 try
                 {
-                    genres = musicService.getGenres(refresh, getContext());
+                    genres = musicService.getGenres(refresh);
                 }
                 catch (Exception x)
                 {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SelectGenreFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SelectGenreFragment.java
@@ -102,7 +102,7 @@ public class SelectGenreFragment extends Fragment {
             @Override
             protected List<Genre> doInBackground()
             {
-                MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                MusicService musicService = MusicServiceFactory.getMusicService();
 
                 List<Genre> genres = new ArrayList<>();
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SelectGenreFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SelectGenreFragment.java
@@ -75,7 +75,7 @@ public class SelectGenreFragment extends Fragment {
                 {
                     Bundle bundle = new Bundle();
                     bundle.putString(Constants.INTENT_EXTRA_NAME_GENRE_NAME, genre.getName());
-                    bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_SIZE, Util.getMaxSongs(getContext()));
+                    bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_SIZE, Util.getMaxSongs());
                     bundle.putInt(Constants.INTENT_EXTRA_NAME_ALBUM_LIST_OFFSET, 0);
                     Navigation.findNavController(view).navigate(R.id.selectAlbumFragment, bundle);
                 }

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
@@ -224,7 +224,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
     private void setupCacheLocationPreference() {
         cacheLocation.setSummary(settings.getString(Constants.PREFERENCES_KEY_CACHE_LOCATION,
-            FileUtil.getDefaultMusicDirectory(getActivity()).getPath()));
+            FileUtil.getDefaultMusicDirectory().getPath()));
 
         cacheLocation.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
@@ -235,7 +235,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
                     public void onPermissionRequestFinished(boolean hasPermission) {
                         if (hasPermission) {
                             FilePickerDialog filePickerDialog = FilePickerDialog.Companion.createFilePickerDialog(getContext());
-                            filePickerDialog.setDefaultDirectory(FileUtil.getDefaultMusicDirectory(getActivity()).getPath());
+                            filePickerDialog.setDefaultDirectory(FileUtil.getDefaultMusicDirectory().getPath());
                             filePickerDialog.setInitialDirectory(cacheLocation.getSummary().toString());
                             filePickerDialog.setOnFileSelectedListener(new OnFileSelectedListener() {
                                 @Override
@@ -448,7 +448,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
         sharingDefaultDescription.setSummary(sharingDefaultDescription.getText());
         sharingDefaultGreeting.setSummary(sharingDefaultGreeting.getText());
         cacheLocation.setSummary(settings.getString(Constants.PREFERENCES_KEY_CACHE_LOCATION,
-            FileUtil.getDefaultMusicDirectory(getActivity()).getPath()));
+            FileUtil.getDefaultMusicDirectory().getPath()));
 
         if (!mediaButtonsEnabled.isChecked()) {
             lockScreenEnabled.setChecked(false);
@@ -462,7 +462,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
         if (debugLogToFile.isChecked()) {
             debugLogToFile.setSummary(getString(R.string.settings_debug_log_path,
-                FileUtil.getUltrasonicDirectory(getActivity()), FileLoggerTree.FILENAME));
+                FileUtil.getUltrasonicDirectory(), FileLoggerTree.FILENAME));
         } else {
             debugLogToFile.setSummary("");
         }
@@ -480,7 +480,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
     }
 
     private void setHideMedia(boolean hide) {
-        File nomediaDir = new File(FileUtil.getUltrasonicDirectory(getActivity()), ".nomedia");
+        File nomediaDir = new File(FileUtil.getUltrasonicDirectory(), ".nomedia");
         if (hide && !nomediaDir.exists()) {
             if (!nomediaDir.mkdir()) {
                 Timber.w("Failed to create %s", nomediaDir);
@@ -510,7 +510,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
                 @Override
                 public void onPermissionRequestFinished(boolean hasPermission) {
                     String currentPath = settings.getString(Constants.PREFERENCES_KEY_CACHE_LOCATION,
-                            FileUtil.getDefaultMusicDirectory(getActivity()).getPath());
+                            FileUtil.getDefaultMusicDirectory().getPath());
                     cacheLocation.setSummary(currentPath);
                 }
             });
@@ -525,18 +525,18 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
     private void setDebugLogToFile(boolean writeLog) {
         if (writeLog) {
-            FileLoggerTree.Companion.plantToTimberForest(getActivity().getApplicationContext());
+            FileLoggerTree.Companion.plantToTimberForest();
             Timber.i("Enabled debug logging to file");
         } else {
             FileLoggerTree.Companion.uprootFromTimberForest();
             Timber.i("Disabled debug logging to file");
 
-            int fileNum = FileLoggerTree.Companion.getLogFileNumber(getActivity());
-            long fileSize = FileLoggerTree.Companion.getLogFileSizes(getActivity());
+            int fileNum = FileLoggerTree.Companion.getLogFileNumber();
+            long fileSize = FileLoggerTree.Companion.getLogFileSizes();
             String message = getString(R.string.settings_debug_log_summary,
                 String.valueOf(fileNum),
                 String.valueOf(Math.ceil(fileSize / 1000000d)),
-                FileUtil.getUltrasonicDirectory(getActivity()));
+                FileUtil.getUltrasonicDirectory());
 
             new AlertDialog.Builder(getActivity())
                 .setMessage(message)
@@ -550,7 +550,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
                 .setPositiveButton(R.string.settings_debug_log_delete, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        FileLoggerTree.Companion.deleteLogFiles(getActivity());
+                        FileLoggerTree.Companion.deleteLogFiles();
                         Timber.i("Deleted debug log files");
                         dialogInterface.dismiss();
                         new AlertDialog.Builder(getActivity()).setMessage(R.string.settings_debug_log_deleted)

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SettingsFragment.java
@@ -166,14 +166,14 @@ public class SettingsFragment extends PreferenceFragmentCompat
     @Override
     public void onResume() {
         super.onResume();
-        SharedPreferences preferences = Util.getPreferences(getActivity());
+        SharedPreferences preferences = Util.getPreferences();
         preferences.registerOnSharedPreferenceChangeListener(this);
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        SharedPreferences prefs = Util.getPreferences(getActivity());
+        SharedPreferences prefs = Util.getPreferences();
         prefs.unregisterOnSharedPreferenceChangeListener(this);
     }
 
@@ -257,8 +257,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
     }
 
     private void setupBluetoothDevicePreferences() {
-        final int resumeSetting = Util.getResumeOnBluetoothDevice(getActivity());
-        final int pauseSetting = Util.getPauseOnBluetoothDevice(getActivity());
+        final int resumeSetting = Util.getResumeOnBluetoothDevice();
+        final int pauseSetting = Util.getPauseOnBluetoothDevice();
 
         resumeOnBluetoothDevice.setSummary(bluetoothDevicePreferenceToString(resumeSetting));
         pauseOnBluetoothDevice.setSummary(bluetoothDevicePreferenceToString(pauseSetting));
@@ -268,7 +268,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
             public boolean onPreferenceClick(Preference preference) {
             showBluetoothDevicePreferenceDialog(
                 R.string.settings_playback_resume_on_bluetooth_device,
-                Util.getResumeOnBluetoothDevice(getActivity()),
+                Util.getResumeOnBluetoothDevice(),
                 new Consumer<Integer>() {
                     @Override
                     public void accept(Integer choice) {
@@ -287,7 +287,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
             public boolean onPreferenceClick(Preference preference) {
             showBluetoothDevicePreferenceDialog(
                 R.string.settings_playback_pause_on_bluetooth_device,
-                Util.getPauseOnBluetoothDevice(getActivity()),
+                Util.getPauseOnBluetoothDevice(),
                 new Consumer<Integer>() {
                     @Override
                     public void accept(Integer choice) {
@@ -467,7 +467,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
             debugLogToFile.setSummary("");
         }
 
-        showArtistPicture.setEnabled(Util.getShouldUseId3Tags(getActivity()));
+        showArtistPicture.setEnabled(Util.getShouldUseId3Tags());
     }
 
     private void setImageLoaderConcurrency(int concurrency) {

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SharesFragment.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/fragment/SharesFragment.java
@@ -128,7 +128,7 @@ public class SharesFragment extends Fragment {
             @Override
             protected List<Share> doInBackground() throws Throwable
             {
-                MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                MusicService musicService = MusicServiceFactory.getMusicService();
                 return musicService.getShares(refresh, getContext());
             }
 
@@ -195,7 +195,7 @@ public class SharesFragment extends Fragment {
                     @Override
                     protected Void doInBackground() throws Throwable
                     {
-                        MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                        MusicService musicService = MusicServiceFactory.getMusicService();
                         musicService.deleteShare(share.getId(), getContext());
                         return null;
                     }
@@ -301,7 +301,7 @@ public class SharesFragment extends Fragment {
                         Editable shareDescriptionText = shareDescription.getText();
                         String description = shareDescriptionText != null ? shareDescriptionText.toString() : null;
 
-                        MusicService musicService = MusicServiceFactory.getMusicService(getContext());
+                        MusicService musicService = MusicServiceFactory.getMusicService();
                         musicService.updateShare(share.getId(), description, millis, getContext());
                         return null;
                     }

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/BluetoothIntentReceiver.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/BluetoothIntentReceiver.java
@@ -66,7 +66,7 @@ public class BluetoothIntentReceiver extends BroadcastReceiver
 		boolean resume = false;
 		boolean pause = false;
 
-		switch (Util.getResumeOnBluetoothDevice(context))
+		switch (Util.getResumeOnBluetoothDevice())
 		{
 			case Constants.PREFERENCE_VALUE_ALL: resume = actionA2dpConnected || actionBluetoothDeviceConnected;
 				break;
@@ -74,7 +74,7 @@ public class BluetoothIntentReceiver extends BroadcastReceiver
 				break;
 		}
 
-		switch (Util.getPauseOnBluetoothDevice(context))
+		switch (Util.getPauseOnBluetoothDevice())
 		{
 			case Constants.PREFERENCE_VALUE_ALL: pause = actionA2dpDisconnected || actionBluetoothDeviceDisconnected;
 				break;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/MediaButtonIntentReceiver.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/receiver/MediaButtonIntentReceiver.java
@@ -46,8 +46,8 @@ public class MediaButtonIntentReceiver extends BroadcastReceiver
 		String intentAction = intent.getAction();
 
 		// If media button are turned off and we received a media button, exit
-		if (!Util.getMediaButtonsEnabled(context) &&
-				Intent.ACTION_MEDIA_BUTTON.equals(intentAction)) return;
+		if (!Util.getMediaButtonsEnabled() && Intent.ACTION_MEDIA_BUTTON.equals(intentAction))
+			return;
 
 		// Only process media buttons and CMD_PROCESS_KEYCODE, which is received from the widgets
 		if (!Intent.ACTION_MEDIA_BUTTON.equals(intentAction) &&

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
@@ -124,7 +124,7 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public Indexes getIndexes(String musicFolderId, boolean refresh, Context context) throws Exception
+	public Indexes getIndexes(String musicFolderId, boolean refresh) throws Exception
 	{
 		checkSettingsChanged();
 		if (refresh)
@@ -136,7 +136,7 @@ public class CachedMusicService implements MusicService
 		Indexes result = cachedIndexes.get();
 		if (result == null)
 		{
-			result = musicService.getIndexes(musicFolderId, refresh, context);
+			result = musicService.getIndexes(musicFolderId, refresh);
 			cachedIndexes.set(result);
 		}
 		return result;
@@ -160,7 +160,7 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public MusicDirectory getMusicDirectory(String id, String name, boolean refresh, Context context) throws Exception
+	public MusicDirectory getMusicDirectory(String id, String name, boolean refresh) throws Exception
 	{
 		checkSettingsChanged();
 		TimeLimitedCache<MusicDirectory> cache = refresh ? null : cachedMusicDirectories.get(id);
@@ -169,7 +169,7 @@ public class CachedMusicService implements MusicService
 
 		if (dir == null)
 		{
-			dir = musicService.getMusicDirectory(id, name, refresh, context);
+			dir = musicService.getMusicDirectory(id, name, refresh);
 			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(dir);
 			cachedMusicDirectories.put(id, cache);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
@@ -36,7 +36,6 @@ import org.moire.ultrasonic.domain.SearchCriteria;
 import org.moire.ultrasonic.domain.SearchResult;
 import org.moire.ultrasonic.domain.Share;
 import org.moire.ultrasonic.domain.UserInfo;
-import org.moire.ultrasonic.util.CancellableTask;
 import org.moire.ultrasonic.util.Constants;
 import org.moire.ultrasonic.util.LRUCache;
 import org.moire.ultrasonic.util.TimeLimitedCache;
@@ -171,7 +170,7 @@ public class CachedMusicService implements MusicService
 		if (dir == null)
 		{
 			dir = musicService.getMusicDirectory(id, name, refresh, context);
-			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(context), TimeUnit.SECONDS);
+			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(dir);
 			cachedMusicDirectories.put(id, cache);
 		}
@@ -187,7 +186,7 @@ public class CachedMusicService implements MusicService
 		if (dir == null)
 		{
 			dir = musicService.getArtist(id, name, refresh, context);
-			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(context), TimeUnit.SECONDS);
+			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(dir);
 			cachedArtist.put(id, cache);
 		}
@@ -203,7 +202,7 @@ public class CachedMusicService implements MusicService
 		if (dir == null)
 		{
 			dir = musicService.getAlbum(id, name, refresh, context);
-			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(context), TimeUnit.SECONDS);
+			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(dir);
 			cachedAlbum.put(id, cache);
 		}
@@ -487,7 +486,7 @@ public class CachedMusicService implements MusicService
 		if (dir == null)
 		{
 			dir = musicService.getVideos(refresh, context);
-			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(context), TimeUnit.SECONDS);
+			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(dir);
 			cachedMusicDirectories.put(Constants.INTENT_EXTRA_NAME_VIDEOS, cache);
 		}
@@ -507,7 +506,7 @@ public class CachedMusicService implements MusicService
 		if (userInfo == null)
 		{
 			userInfo = musicService.getUser(username, context);
-			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(context), TimeUnit.SECONDS);
+			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(userInfo);
 			cachedUserInfo.put(username, cache);
 		}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/CachedMusicService.java
@@ -87,27 +87,27 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public void ping(Context context) throws Exception
+	public void ping() throws Exception
 	{
 		checkSettingsChanged();
-		musicService.ping(context);
+		musicService.ping();
 	}
 
 	@Override
-	public boolean isLicenseValid(Context context) throws Exception
+	public boolean isLicenseValid() throws Exception
 	{
 		checkSettingsChanged();
 		Boolean result = cachedLicenseValid.get();
 		if (result == null)
 		{
-			result = musicService.isLicenseValid(context);
+			result = musicService.isLicenseValid();
 			cachedLicenseValid.set(result, result ? 30L * 60L : 2L * 60L, TimeUnit.SECONDS);
 		}
 		return result;
 	}
 
 	@Override
-	public List<MusicFolder> getMusicFolders(boolean refresh, Context context) throws Exception
+	public List<MusicFolder> getMusicFolders(boolean refresh) throws Exception
 	{
 		checkSettingsChanged();
 		if (refresh)
@@ -117,7 +117,7 @@ public class CachedMusicService implements MusicService
 		List<MusicFolder> result = cachedMusicFolders.get();
 		if (result == null)
 		{
-			result = musicService.getMusicFolders(refresh, context);
+			result = musicService.getMusicFolders(refresh);
 			cachedMusicFolders.set(result);
 		}
 		return result;
@@ -143,7 +143,7 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public Indexes getArtists(boolean refresh, Context context) throws Exception
+	public Indexes getArtists(boolean refresh) throws Exception
 	{
 		checkSettingsChanged();
 		if (refresh)
@@ -153,7 +153,7 @@ public class CachedMusicService implements MusicService
 		Indexes result = cachedArtists.get();
 		if (result == null)
 		{
-			result = musicService.getArtists(refresh, context);
+			result = musicService.getArtists(refresh);
 			cachedArtists.set(result);
 		}
 		return result;
@@ -178,14 +178,14 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public MusicDirectory getArtist(String id, String name, boolean refresh, Context context) throws Exception
+	public MusicDirectory getArtist(String id, String name, boolean refresh) throws Exception
 	{
 		checkSettingsChanged();
 		TimeLimitedCache<MusicDirectory> cache = refresh ? null : cachedArtist.get(id);
 		MusicDirectory dir = cache == null ? null : cache.get();
 		if (dir == null)
 		{
-			dir = musicService.getArtist(id, name, refresh, context);
+			dir = musicService.getArtist(id, name, refresh);
 			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(dir);
 			cachedArtist.put(id, cache);
@@ -194,14 +194,14 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public MusicDirectory getAlbum(String id, String name, boolean refresh, Context context) throws Exception
+	public MusicDirectory getAlbum(String id, String name, boolean refresh) throws Exception
 	{
 		checkSettingsChanged();
 		TimeLimitedCache<MusicDirectory> cache = refresh ? null : cachedAlbum.get(id);
 		MusicDirectory dir = cache == null ? null : cache.get();
 		if (dir == null)
 		{
-			dir = musicService.getAlbum(id, name, refresh, context);
+			dir = musicService.getAlbum(id, name, refresh);
 			cache = new TimeLimitedCache<>(Util.getDirectoryCacheTime(), TimeUnit.SECONDS);
 			cache.set(dir);
 			cachedAlbum.put(id, cache);
@@ -284,15 +284,15 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public MusicDirectory getAlbumList(String type, int size, int offset, String musicFolderId, Context context) throws Exception
+	public MusicDirectory getAlbumList(String type, int size, int offset, String musicFolderId) throws Exception
 	{
-		return musicService.getAlbumList(type, size, offset, musicFolderId, context);
+		return musicService.getAlbumList(type, size, offset, musicFolderId);
 	}
 
 	@Override
-	public MusicDirectory getAlbumList2(String type, int size, int offset, String musicFolderId, Context context) throws Exception
+	public MusicDirectory getAlbumList2(String type, int size, int offset, String musicFolderId) throws Exception
 	{
-		return musicService.getAlbumList2(type, size, offset, musicFolderId, context);
+		return musicService.getAlbumList2(type, size, offset, musicFolderId);
 	}
 
 	@Override
@@ -302,15 +302,15 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public SearchResult getStarred(Context context) throws Exception
+	public SearchResult getStarred() throws Exception
 	{
-		return musicService.getStarred(context);
+		return musicService.getStarred();
 	}
 
 	@Override
-	public SearchResult getStarred2(Context context) throws Exception
+	public SearchResult getStarred2() throws Exception
 	{
-		return musicService.getStarred2(context);
+		return musicService.getStarred2();
 	}
 
 	@Override
@@ -388,25 +388,25 @@ public class CachedMusicService implements MusicService
 	}
 
 	@Override
-	public void star(String id, String albumId, String artistId, Context context) throws Exception
+	public void star(String id, String albumId, String artistId) throws Exception
 	{
-		musicService.star(id, albumId, artistId, context);
+		musicService.star(id, albumId, artistId);
 	}
 
 	@Override
-	public void unstar(String id, String albumId, String artistId, Context context) throws Exception
+	public void unstar(String id, String albumId, String artistId) throws Exception
 	{
-		musicService.unstar(id, albumId, artistId, context);
+		musicService.unstar(id, albumId, artistId);
 	}
 
 	@Override
-	public void setRating(String id, int rating, Context context) throws Exception
+	public void setRating(String id, int rating) throws Exception
 	{
-		musicService.setRating(id, rating, context);
+		musicService.setRating(id, rating);
 	}
 
 	@Override
-	public List<Genre> getGenres(boolean refresh, Context context) throws Exception
+	public List<Genre> getGenres(boolean refresh) throws Exception
 	{
 		checkSettingsChanged();
 		if (refresh)
@@ -417,7 +417,7 @@ public class CachedMusicService implements MusicService
 
 		if (result == null)
 		{
-			result = musicService.getGenres(refresh, context);
+			result = musicService.getGenres(refresh);
 			cachedGenres.set(result);
 		}
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/Downloader.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/Downloader.java
@@ -158,7 +158,7 @@ public class Downloader
                 DownloadFile downloadFile = downloadList.get(i);
                 if (!downloadFile.isWorkDone())
                 {
-                    if (downloadFile.shouldSave() || preloaded < Util.getPreloadCount(context))
+                    if (downloadFile.shouldSave() || preloaded < Util.getPreloadCount())
                     {
                         currentDownloading = downloadFile;
                         currentDownloading.download();
@@ -181,7 +181,7 @@ public class Downloader
         }
 
         // If the downloadList contains no work, check the backgroundDownloadList
-        if ((preloaded + 1 == n || preloaded >= Util.getPreloadCount(context) || downloadList.isEmpty()) && !backgroundDownloadList.isEmpty())
+        if ((preloaded + 1 == n || preloaded >= Util.getPreloadCount() || downloadList.isEmpty()) && !backgroundDownloadList.isEmpty())
         {
             for (int i = 0; i < backgroundDownloadList.size(); i++)
             {
@@ -401,7 +401,7 @@ public class Downloader
     private synchronized void checkShufflePlay(Context context)
     {
         // Get users desired random playlist size
-        int listSize = Util.getMaxSongs(context);
+        int listSize = Util.getMaxSongs();
         boolean wasEmpty = downloadList.isEmpty();
 
         long revisionBefore = revision;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/JukeboxMediaPlayer.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/JukeboxMediaPlayer.java
@@ -160,7 +160,7 @@ public class JukeboxMediaPlayer
 
 			try
 			{
-				if (!ActiveServerProvider.Companion.isOffline(context))
+				if (!ActiveServerProvider.Companion.isOffline())
 				{
 					task = tasks.take();
 					JukeboxStatus status = task.execute();

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/JukeboxMediaPlayer.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/JukeboxMediaPlayer.java
@@ -300,7 +300,7 @@ public class JukeboxMediaPlayer
 
 	private MusicService getMusicService()
 	{
-		return MusicServiceFactory.getMusicService(context);
+		return MusicServiceFactory.getMusicService();
 	}
 
 	public int getPositionSeconds()

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
@@ -309,13 +309,13 @@ public class MediaPlayerControllerImpl implements MediaPlayerController
 	@Override
 	public RepeatMode getRepeatMode()
 	{
-		return Util.getRepeatMode(context);
+		return Util.getRepeatMode();
 	}
 
 	@Override
 	public synchronized void setRepeatMode(RepeatMode repeatMode)
 	{
-		Util.setRepeatMode(context, repeatMode);
+		Util.setRepeatMode(repeatMode);
 		MediaPlayerService mediaPlayerService = MediaPlayerService.getRunningInstance();
 		if (mediaPlayerService != null) mediaPlayerService.setNextPlaying();
 	}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
@@ -527,7 +527,7 @@ public class MediaPlayerControllerImpl implements MediaPlayerController
 		try
 		{
 			String username = activeServerProvider.getValue().getActiveServer().getUserName();
-			UserInfo user = MusicServiceFactory.getMusicService(context).getUser(username, context);
+			UserInfo user = MusicServiceFactory.getMusicService().getUser(username, context);
 			return user.getJukeboxRole();
 		}
 		catch (Exception e)
@@ -608,7 +608,7 @@ public class MediaPlayerControllerImpl implements MediaPlayerController
 		new Thread(() -> {
 			try
 			{
-				MusicServiceFactory.getMusicService(context).setRating(song.getId(), rating);
+				MusicServiceFactory.getMusicService().setRating(song.getId(), rating);
 			}
 			catch (Exception e)
 			{

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerControllerImpl.java
@@ -608,7 +608,7 @@ public class MediaPlayerControllerImpl implements MediaPlayerController
 		new Thread(() -> {
 			try
 			{
-				MusicServiceFactory.getMusicService(context).setRating(song.getId(), rating, context);
+				MusicServiceFactory.getMusicService(context).setRating(song.getId(), rating);
 			}
 			catch (Exception e)
 			{

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MediaPlayerLifecycleSupport.java
@@ -138,7 +138,7 @@ public class MediaPlayerLifecycleSupport
 	 * while Ultrasonic is running.
 	 */
 	private void registerHeadsetReceiver() {
-        final SharedPreferences sp = Util.getPreferences(context);
+        final SharedPreferences sp = Util.getPreferences();
         final String spKey = context
                 .getString(R.string.settings_playback_resume_play_on_headphones_plug);
 
@@ -190,7 +190,7 @@ public class MediaPlayerLifecycleSupport
 		final int keyCode;
 		int receivedKeyCode = event.getKeyCode();
 		// Translate PLAY and PAUSE codes to PLAY_PAUSE to improve compatibility with old Bluetooth devices
-		if (Util.getSingleButtonPlayPause(context) &&
+		if (Util.getSingleButtonPlayPause() &&
 			(receivedKeyCode == KeyEvent.KEYCODE_MEDIA_PLAY ||
 				receivedKeyCode == KeyEvent.KEYCODE_MEDIA_PAUSE)) {
 			Timber.i("Single button Play/Pause is set, rewriting keyCode to PLAY_PAUSE");

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MusicService.java
@@ -35,7 +35,6 @@ import org.moire.ultrasonic.domain.SearchCriteria;
 import org.moire.ultrasonic.domain.SearchResult;
 import org.moire.ultrasonic.domain.Share;
 import org.moire.ultrasonic.domain.UserInfo;
-import org.moire.ultrasonic.util.CancellableTask;
 
 import java.io.InputStream;
 import java.util.List;
@@ -48,29 +47,29 @@ import kotlin.Pair;
 public interface MusicService
 {
 
-	void ping(Context context) throws Exception;
+	void ping() throws Exception;
 
-	boolean isLicenseValid(Context context) throws Exception;
+	boolean isLicenseValid() throws Exception;
 
-	List<Genre> getGenres(boolean refresh, Context context) throws Exception;
+	List<Genre> getGenres(boolean refresh) throws Exception;
 
-	void star(String id, String albumId, String artistId, Context context) throws Exception;
+	void star(String id, String albumId, String artistId) throws Exception;
 
-	void unstar(String id, String albumId, String artistId, Context context) throws Exception;
+	void unstar(String id, String albumId, String artistId) throws Exception;
 
-	void setRating(String id, int rating, Context context) throws Exception;
+	void setRating(String id, int rating) throws Exception;
 
-	List<MusicFolder> getMusicFolders(boolean refresh, Context context) throws Exception;
+	List<MusicFolder> getMusicFolders(boolean refresh) throws Exception;
 
 	Indexes getIndexes(String musicFolderId, boolean refresh, Context context) throws Exception;
 
-	Indexes getArtists(boolean refresh, Context context) throws Exception;
+	Indexes getArtists(boolean refresh) throws Exception;
 
 	MusicDirectory getMusicDirectory(String id, String name, boolean refresh, Context context) throws Exception;
 
-	MusicDirectory getArtist(String id, String name, boolean refresh, Context context) throws Exception;
+	MusicDirectory getArtist(String id, String name, boolean refresh) throws Exception;
 
-	MusicDirectory getAlbum(String id, String name, boolean refresh, Context context) throws Exception;
+	MusicDirectory getAlbum(String id, String name, boolean refresh) throws Exception;
 
 	SearchResult search(SearchCriteria criteria, Context context) throws Exception;
 
@@ -90,17 +89,17 @@ public interface MusicService
 
 	void scrobble(String id, boolean submission, Context context) throws Exception;
 
-	MusicDirectory getAlbumList(String type, int size, int offset, String musicFolderId, Context context) throws Exception;
+	MusicDirectory getAlbumList(String type, int size, int offset, String musicFolderId) throws Exception;
 
-	MusicDirectory getAlbumList2(String type, int size, int offset, String musicFolderId, Context context) throws Exception;
+	MusicDirectory getAlbumList2(String type, int size, int offset, String musicFolderId) throws Exception;
 
 	MusicDirectory getRandomSongs(int size, Context context) throws Exception;
 
 	MusicDirectory getSongsByGenre(String genre, int count, int offset, Context context) throws Exception;
 
-	SearchResult getStarred(Context context) throws Exception;
+	SearchResult getStarred() throws Exception;
 
-	SearchResult getStarred2(Context context) throws Exception;
+	SearchResult getStarred2() throws Exception;
 
 	Bitmap getCoverArt(Context context, MusicDirectory.Entry entry, int size, boolean saveToFile, boolean highQuality) throws Exception;
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/MusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/MusicService.java
@@ -61,11 +61,11 @@ public interface MusicService
 
 	List<MusicFolder> getMusicFolders(boolean refresh) throws Exception;
 
-	Indexes getIndexes(String musicFolderId, boolean refresh, Context context) throws Exception;
+	Indexes getIndexes(String musicFolderId, boolean refresh) throws Exception;
 
 	Indexes getArtists(boolean refresh) throws Exception;
 
-	MusicDirectory getMusicDirectory(String id, String name, boolean refresh, Context context) throws Exception;
+	MusicDirectory getMusicDirectory(String id, String name, boolean refresh) throws Exception;
 
 	MusicDirectory getArtist(String id, String name, boolean refresh) throws Exception;
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/OfflineMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/OfflineMusicService.java
@@ -41,7 +41,6 @@ import org.moire.ultrasonic.domain.SearchCriteria;
 import org.moire.ultrasonic.domain.SearchResult;
 import org.moire.ultrasonic.domain.Share;
 import org.moire.ultrasonic.domain.UserInfo;
-import org.moire.ultrasonic.util.CancellableTask;
 import org.moire.ultrasonic.util.Constants;
 import org.moire.ultrasonic.util.FileUtil;
 import org.moire.ultrasonic.util.Util;
@@ -702,7 +701,7 @@ public class OfflineMusicService implements MusicService
 	}
 
 	@Override
-	public MusicDirectory getAlbumList(String type, int size, int offset, String musicFolderId, Context context) throws Exception
+	public MusicDirectory getAlbumList(String type, int size, int offset, String musicFolderId) throws Exception
 	{
 		throw new OfflineException("Album lists not available in offline mode");
 	}
@@ -744,7 +743,7 @@ public class OfflineMusicService implements MusicService
 	}
 
 	@Override
-	public SearchResult getStarred(Context context) throws Exception
+	public SearchResult getStarred() throws Exception
 	{
 		throw new OfflineException("Starred not available in offline mode");
 	}
@@ -756,7 +755,7 @@ public class OfflineMusicService implements MusicService
 	}
 
 	@Override
-	public List<Genre> getGenres(boolean refresh, Context context) throws Exception
+	public List<Genre> getGenres(boolean refresh) throws Exception
 	{
 		throw new OfflineException("Getting Genres not available in offline mode");
 	}
@@ -792,24 +791,24 @@ public class OfflineMusicService implements MusicService
 	}
 
 	@Override
-	public void star(String id, String albumId, String artistId, Context context) throws Exception
+	public void star(String id, String albumId, String artistId) throws Exception
 	{
 		throw new OfflineException("Star not available in offline mode");
 	}
 
 	@Override
-	public void unstar(String id, String albumId, String artistId, Context context) throws Exception
+	public void unstar(String id, String albumId, String artistId) throws Exception
 	{
 		throw new OfflineException("UnStar not available in offline mode");
 	}
 	@Override
-	public List<MusicFolder> getMusicFolders(boolean refresh, Context context) throws Exception
+	public List<MusicFolder> getMusicFolders(boolean refresh) throws Exception
 	{
 		throw new OfflineException("Music folders not available in offline mode");
 	}
 
 	@Override
-	public MusicDirectory getAlbumList2(String type, int size, int offset, String musicFolderId, Context context) {
+	public MusicDirectory getAlbumList2(String type, int size, int offset, String musicFolderId) {
 		Timber.w("OfflineMusicService.getAlbumList2 was called but it isn't available");
 		return null;
 	}
@@ -854,34 +853,34 @@ public class OfflineMusicService implements MusicService
 	}
 
 	@Override
-	public SearchResult getStarred2(Context context) {
+	public SearchResult getStarred2() {
 		Timber.w("OfflineMusicService.getStarred2 was called but it isn't available");
 		return null;
 	}
 
 	@Override
-	public void ping(Context context) {
+	public void ping() {
 	}
 
 	@Override
-	public boolean isLicenseValid(Context context) {
+	public boolean isLicenseValid() {
 		return true;
 	}
 
 	@Override
-	public Indexes getArtists(boolean refresh, Context context) {
+	public Indexes getArtists(boolean refresh) {
 		Timber.w("OfflineMusicService.getArtists was called but it isn't available");
 		return null;
 	}
 
 	@Override
-	public MusicDirectory getArtist(String id, String name, boolean refresh, Context context) {
+	public MusicDirectory getArtist(String id, String name, boolean refresh) {
 		Timber.w("OfflineMusicService.getArtist was called but it isn't available");
 		return null;
 	}
 
 	@Override
-	public MusicDirectory getAlbum(String id, String name, boolean refresh, Context context) {
+	public MusicDirectory getAlbum(String id, String name, boolean refresh) {
 		Timber.w("OfflineMusicService.getAlbum was called but it isn't available");
 		return null;
 	}
@@ -899,7 +898,7 @@ public class OfflineMusicService implements MusicService
 	}
 
 	@Override
-	public void setRating(String id, int rating, Context context) {
+	public void setRating(String id, int rating) {
 		Timber.w("OfflineMusicService.setRating was called but it isn't available");
 	}
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/OfflineMusicService.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/OfflineMusicService.java
@@ -77,10 +77,10 @@ public class OfflineMusicService implements MusicService
 	private final Lazy<ActiveServerProvider> activeServerProvider = inject(ActiveServerProvider.class);
 
 	@Override
-	public Indexes getIndexes(String musicFolderId, boolean refresh, Context context)
+	public Indexes getIndexes(String musicFolderId, boolean refresh)
 	{
 		List<Artist> artists = new ArrayList<>();
-		File root = FileUtil.getMusicDirectory(context);
+		File root = FileUtil.getMusicDirectory();
 		for (File file : FileUtil.listFiles(root))
 		{
 			if (file.isDirectory())
@@ -142,7 +142,7 @@ public class OfflineMusicService implements MusicService
 	}
 
 	@Override
-	public MusicDirectory getMusicDirectory(String id, String artistName, boolean refresh, Context context)
+	public MusicDirectory getMusicDirectory(String id, String artistName, boolean refresh)
 	{
 		File dir = new File(id);
 		MusicDirectory result = new MusicDirectory();
@@ -156,7 +156,7 @@ public class OfflineMusicService implements MusicService
 			if (name != null & !names.contains(name))
 			{
 				names.add(name);
-				result.addChild(createEntry(context, file, name));
+				result.addChild(createEntry(file, name));
 			}
 		}
 
@@ -181,14 +181,14 @@ public class OfflineMusicService implements MusicService
 		return FileUtil.getBaseName(name);
 	}
 
-	private static MusicDirectory.Entry createEntry(Context context, File file, String name)
+	private static MusicDirectory.Entry createEntry(File file, String name)
 	{
 		MusicDirectory.Entry entry = new MusicDirectory.Entry();
 		entry.setDirectory(file.isDirectory());
 		entry.setId(file.getPath());
 		entry.setParent(file.getParent());
 		entry.setSize(file.length());
-		String root = FileUtil.getMusicDirectory(context).getPath();
+		String root = FileUtil.getMusicDirectory().getPath();
 		entry.setPath(file.getPath().replaceFirst(String.format("^%s/", root), ""));
 		entry.setTitle(name);
 
@@ -322,7 +322,7 @@ public class OfflineMusicService implements MusicService
 
 		entry.setSuffix(FileUtil.getExtension(file.getName().replace(".complete", "")));
 
-		File albumArt = FileUtil.getAlbumArtFile(context, entry);
+		File albumArt = FileUtil.getAlbumArtFile(entry);
 
 		if (albumArt.exists())
 		{
@@ -337,7 +337,7 @@ public class OfflineMusicService implements MusicService
 	{
 		try
 		{
-			Bitmap bitmap = FileUtil.getAvatarBitmap(context, username, size, highQuality);
+			Bitmap bitmap = FileUtil.getAvatarBitmap(username, size, highQuality);
 			return Util.scaleBitmap(bitmap, size);
 		}
 		catch (Exception e)
@@ -366,7 +366,7 @@ public class OfflineMusicService implements MusicService
 		List<Artist> artists = new ArrayList<>();
 		List<MusicDirectory.Entry> albums = new ArrayList<>();
 		List<MusicDirectory.Entry> songs = new ArrayList<>();
-		File root = FileUtil.getMusicDirectory(context);
+		File root = FileUtil.getMusicDirectory();
 		int closeness;
 
 		for (File artistFile : FileUtil.listFiles(root))
@@ -442,7 +442,7 @@ public class OfflineMusicService implements MusicService
 				String albumName = getName(albumFile);
 				if ((closeness = matchCriteria(criteria, albumName)) > 0)
 				{
-					MusicDirectory.Entry album = createEntry(context, albumFile, albumName);
+					MusicDirectory.Entry album = createEntry(albumFile, albumName);
 					album.setArtist(artistName);
 					album.setCloseness(closeness);
 					albums.add(album);
@@ -458,7 +458,7 @@ public class OfflineMusicService implements MusicService
 					}
 					else if ((closeness = matchCriteria(criteria, songName)) > 0)
 					{
-						MusicDirectory.Entry song = createEntry(context, albumFile, songName);
+						MusicDirectory.Entry song = createEntry(albumFile, songName);
 						song.setArtist(artistName);
 						song.setAlbum(albumName);
 						song.setCloseness(closeness);
@@ -472,7 +472,7 @@ public class OfflineMusicService implements MusicService
 
 				if ((closeness = matchCriteria(criteria, songName)) > 0)
 				{
-					MusicDirectory.Entry song = createEntry(context, albumFile, songName);
+					MusicDirectory.Entry song = createEntry(albumFile, songName);
 					song.setArtist(artistName);
 					song.setAlbum(songName);
 					song.setCloseness(closeness);
@@ -508,7 +508,7 @@ public class OfflineMusicService implements MusicService
 	public List<Playlist> getPlaylists(boolean refresh, Context context)
 	{
 		List<Playlist> playlists = new ArrayList<>();
-		File root = FileUtil.getPlaylistDirectory(context);
+		File root = FileUtil.getPlaylistDirectory();
 		String lastServer = null;
 		boolean removeServer = true;
 		for (File folder : FileUtil.listFiles(root))
@@ -577,7 +577,7 @@ public class OfflineMusicService implements MusicService
 				name = name.substring(id.length() + 2);
 			}
 
-			File playlistFile = FileUtil.getPlaylistFile(context, id, name);
+			File playlistFile = FileUtil.getPlaylistFile(id, name);
 			reader = new FileReader(playlistFile);
 			buffer = new BufferedReader(reader);
 
@@ -592,7 +592,7 @@ public class OfflineMusicService implements MusicService
 
 				if (entryFile.exists() && entryName != null)
 				{
-					playlist.addChild(createEntry(context, entryFile, entryName));
+					playlist.addChild(createEntry(entryFile, entryName));
 				}
 			}
 
@@ -608,7 +608,7 @@ public class OfflineMusicService implements MusicService
 	@Override
 	public void createPlaylist(String id, String name, List<MusicDirectory.Entry> entries, Context context) throws Exception
 	{
-		File playlistFile = FileUtil.getPlaylistFile(context, activeServerProvider.getValue().getActiveServer().getName(), name);
+		File playlistFile = FileUtil.getPlaylistFile(activeServerProvider.getValue().getActiveServer().getName(), name);
 		FileWriter fw = new FileWriter(playlistFile);
 		BufferedWriter bw = new BufferedWriter(fw);
 		try
@@ -616,7 +616,7 @@ public class OfflineMusicService implements MusicService
 			fw.write("#EXTM3U\n");
 			for (MusicDirectory.Entry e : entries)
 			{
-				String filePath = FileUtil.getSongFile(context, e).getAbsolutePath();
+				String filePath = FileUtil.getSongFile(e).getAbsolutePath();
 				if (!new File(filePath).exists())
 				{
 					String ext = FileUtil.getExtension(filePath);
@@ -641,7 +641,7 @@ public class OfflineMusicService implements MusicService
 	@Override
 	public MusicDirectory getRandomSongs(int size, Context context)
 	{
-		File root = FileUtil.getMusicDirectory(context);
+		File root = FileUtil.getMusicDirectory();
 		List<File> children = new LinkedList<>();
 		listFilesRecursively(root, children);
 		MusicDirectory result = new MusicDirectory();
@@ -655,7 +655,7 @@ public class OfflineMusicService implements MusicService
 		for (int i = 0; i < size; i++)
 		{
 			File file = children.get(random.nextInt(children.size()));
-			result.addChild(createEntry(context, file, getName(file)));
+			result.addChild(createEntry(file, getName(file)));
 		}
 
 		return result;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/Scrobbler.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/Scrobbler.java
@@ -36,7 +36,7 @@ public class Scrobbler
 			@Override
 			public void run()
 			{
-				MusicService service = MusicServiceFactory.getMusicService(context);
+				MusicService service = MusicServiceFactory.getMusicService();
 				try
 				{
 					service.scrobble(id, submission, context);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/service/Scrobbler.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/service/Scrobbler.java
@@ -18,7 +18,7 @@ public class Scrobbler
 
 	public void scrobble(final Context context, final DownloadFile song, final boolean submission)
 	{
-		if (song == null || !ActiveServerProvider.Companion.isScrobblingEnabled(context)) return;
+		if (song == null || !ActiveServerProvider.Companion.isScrobblingEnabled()) return;
 
 		final String id = song.getSong().getId();
 		if (id == null) return;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/AlbumHeader.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/AlbumHeader.java
@@ -70,7 +70,7 @@ public class AlbumHeader
 
 			if (!entry.isDirectory())
 			{
-				if (Util.shouldUseFolderForArtistName(context))
+				if (Util.shouldUseFolderForArtistName())
 				{
 					albumHeader.processGrandParents(entry);
 				}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/CacheCleaner.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/CacheCleaner.java
@@ -98,9 +98,9 @@ public class CacheCleaner
 			if (children != null)
 			{
 				// No songs left in the folder
-				if (children.length == 1 && children[0].getPath().equals(FileUtil.getAlbumArtFile(context, dir).getPath()))
+				if (children.length == 1 && children[0].getPath().equals(FileUtil.getAlbumArtFile(dir).getPath()))
 				{
-					Util.delete(FileUtil.getAlbumArtFile(context, dir));
+					Util.delete(FileUtil.getAlbumArtFile(dir));
 					children = dir.listFiles();
 				}
 
@@ -232,7 +232,7 @@ public class CacheCleaner
 			filesToNotDelete.add(downloadFile.getCompleteOrSaveFile());
 		}
 
-		filesToNotDelete.add(FileUtil.getMusicDirectory(context));
+		filesToNotDelete.add(FileUtil.getMusicDirectory());
 		return filesToNotDelete;
 	}
 
@@ -247,7 +247,7 @@ public class CacheCleaner
 				List<File> files = new ArrayList<File>();
 				List<File> dirs = new ArrayList<File>();
 
-				findCandidatesForDeletion(FileUtil.getMusicDirectory(context), files, dirs);
+				findCandidatesForDeletion(FileUtil.getMusicDirectory(), files, dirs);
 				sortByAscendingModificationTime(files);
 
 				Set<File> filesToNotDelete = findFilesToNotDelete();
@@ -274,7 +274,7 @@ public class CacheCleaner
 				Thread.currentThread().setName("BackgroundSpaceCleanup");
 				List<File> files = new ArrayList<File>();
 				List<File> dirs = new ArrayList<File>();
-				findCandidatesForDeletion(FileUtil.getMusicDirectory(context), files, dirs);
+				findCandidatesForDeletion(FileUtil.getMusicDirectory(), files, dirs);
 
 				long bytesToDelete = getMinimumDelete(files);
 				if (bytesToDelete > 0L)
@@ -302,11 +302,11 @@ public class CacheCleaner
 			{
 				Thread.currentThread().setName("BackgroundPlaylistsCleanup");
 				String server = activeServerProvider.getValue().getActiveServer().getName();
-				SortedSet<File> playlistFiles = FileUtil.listFiles(FileUtil.getPlaylistDirectory(context, server));
+				SortedSet<File> playlistFiles = FileUtil.listFiles(FileUtil.getPlaylistDirectory(server));
 				List<Playlist> playlists = params[0];
 				for (Playlist playlist : playlists)
 				{
-					playlistFiles.remove(FileUtil.getPlaylistFile(context, server, playlist.getName()));
+					playlistFiles.remove(FileUtil.getPlaylistFile(server, playlist.getName()));
 				}
 
 				for (File playlist : playlistFiles)

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/CacheCleaner.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/CacheCleaner.java
@@ -120,7 +120,7 @@ public class CacheCleaner
 			return 0L;
 		}
 
-		long cacheSizeBytes = Util.getCacheSizeMB(context) * 1024L * 1024L;
+		long cacheSizeBytes = Util.getCacheSizeMB() * 1024L * 1024L;
 		long bytesUsedBySubsonic = 0L;
 
 		for (File file : files)

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/FileUtil.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/FileUtil.java
@@ -380,7 +380,7 @@ public class FileUtil
 	public static File getMusicDirectory(Context context)
 	{
 		File defaultMusicDirectory = getDefaultMusicDirectory(context);
-		String path = Util.getPreferences(context).getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, defaultMusicDirectory.getPath());
+		String path = Util.getPreferences().getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, defaultMusicDirectory.getPath());
 		File dir = new File(path);
 
 		boolean hasAccess = ensureDirectoryExistsAndIsReadWritable(dir);

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/LegacyImageLoader.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/LegacyImageLoader.java
@@ -416,7 +416,7 @@ public class LegacyImageLoader implements Runnable, ImageLoader {
 
         public void execute() {
             try {
-                MusicService musicService = MusicServiceFactory.getMusicService(view.getContext());
+                MusicService musicService = MusicServiceFactory.getMusicService();
                 final boolean isAvatar = this.username != null && this.entry == null;
                 final Bitmap bitmap = this.entry != null ?
                     musicService.getCoverArt(view.getContext(), entry, size, saveToFile, highQuality) :

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/PermissionUtil.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/PermissionUtil.java
@@ -60,7 +60,7 @@ public class PermissionUtil {
      * @param callback callback function to execute after the permission request is finished
      */
     public void handlePermissionFailed(final PermissionRequestFinishedCallback callback) {
-        String currentCachePath = Util.getPreferences(applicationContext).getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, FileUtil.getDefaultMusicDirectory(applicationContext).getPath());
+        String currentCachePath = Util.getPreferences().getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, FileUtil.getDefaultMusicDirectory(applicationContext).getPath());
         String defaultCachePath = FileUtil.getDefaultMusicDirectory(applicationContext).getPath();
 
         // Ultrasonic can do nothing about this error when the Music Directory is already set to the default.
@@ -136,7 +136,7 @@ public class PermissionUtil {
     }
 
     private static void setCacheLocation(Context context, String cacheLocation) {
-        Util.getPreferences(context).edit()
+        Util.getPreferences().edit()
                 .putString(Constants.PREFERENCES_KEY_CACHE_LOCATION, cacheLocation)
                 .apply();
     }

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/PermissionUtil.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/PermissionUtil.java
@@ -60,8 +60,8 @@ public class PermissionUtil {
      * @param callback callback function to execute after the permission request is finished
      */
     public void handlePermissionFailed(final PermissionRequestFinishedCallback callback) {
-        String currentCachePath = Util.getPreferences().getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, FileUtil.getDefaultMusicDirectory(applicationContext).getPath());
-        String defaultCachePath = FileUtil.getDefaultMusicDirectory(applicationContext).getPath();
+        String currentCachePath = Util.getPreferences().getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, FileUtil.getDefaultMusicDirectory().getPath());
+        String defaultCachePath = FileUtil.getDefaultMusicDirectory().getPath();
 
         // Ultrasonic can do nothing about this error when the Music Directory is already set to the default.
         if (currentCachePath.compareTo(defaultCachePath) == 0) return;
@@ -69,12 +69,12 @@ public class PermissionUtil {
         if ((PermissionChecker.checkSelfPermission(applicationContext, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PERMISSION_DENIED) ||
                 (PermissionChecker.checkSelfPermission(applicationContext, Manifest.permission.READ_EXTERNAL_STORAGE) == PERMISSION_DENIED)) {
             // While we request permission, the Music Directory is temporarily reset to its default location
-            setCacheLocation(applicationContext, FileUtil.getDefaultMusicDirectory(applicationContext).getPath());
+            setCacheLocation(applicationContext, FileUtil.getDefaultMusicDirectory().getPath());
             // If the application is not running, we can't notify the user
             if (activityContext == null) return;
             requestFailedPermission(activityContext, currentCachePath, callback);
         } else {
-            setCacheLocation(applicationContext, FileUtil.getDefaultMusicDirectory(applicationContext).getPath());
+            setCacheLocation(applicationContext, FileUtil.getDefaultMusicDirectory().getPath());
             // If the application is not running, we can't notify the user
             if (activityContext != null) {
                 new Handler(Looper.getMainLooper()).post(new Runnable() {
@@ -164,7 +164,7 @@ public class PermissionUtil {
                         }
 
                         Timber.i("At least one permission is missing to use directory %s ", cacheLocation);
-                        setCacheLocation(context, FileUtil.getDefaultMusicDirectory(context).getPath());
+                        setCacheLocation(context, FileUtil.getDefaultMusicDirectory().getPath());
                         showWarning(context, context.getString(R.string.permissions_message_box_title),
                                 context.getString(R.string.permissions_permission_missing), null);
                         if (callback != null) callback.onPermissionRequestFinished(false);
@@ -201,7 +201,7 @@ public class PermissionUtil {
         builder.setNegativeButton(context.getString(R.string.common_cancel), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                setCacheLocation(context, FileUtil.getDefaultMusicDirectory(context).getPath());
+                setCacheLocation(context, FileUtil.getDefaultMusicDirectory().getPath());
                 dialog.cancel();
             }
         });

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/ShufflePlayBuffer.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/ShufflePlayBuffer.java
@@ -104,7 +104,7 @@ public class ShufflePlayBuffer
 
 		try
 		{
-			MusicService service = MusicServiceFactory.getMusicService(context);
+			MusicService service = MusicServiceFactory.getMusicService();
 			int n = CAPACITY - buffer.size();
 			MusicDirectory songs = service.getRandomSongs(n, context);
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/ShufflePlayBuffer.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/ShufflePlayBuffer.java
@@ -97,7 +97,7 @@ public class ShufflePlayBuffer
 		// Check if active server has changed.
 		clearBufferIfNecessary();
 
-		if (buffer.size() > REFILL_THRESHOLD || (!Util.isNetworkConnected(context) && !ActiveServerProvider.Companion.isOffline(context)))
+		if (buffer.size() > REFILL_THRESHOLD || (!Util.isNetworkConnected(context) && !ActiveServerProvider.Companion.isOffline()))
 		{
 			return;
 		}
@@ -124,9 +124,9 @@ public class ShufflePlayBuffer
 	{
 		synchronized (buffer)
 		{
-			if (currentServer != ActiveServerProvider.Companion.getActiveServerId(context))
+			if (currentServer != ActiveServerProvider.Companion.getActiveServerId())
 			{
-				currentServer = ActiveServerProvider.Companion.getActiveServerId(context);
+				currentServer = ActiveServerProvider.Companion.getActiveServerId();
 				buffer.clear();
 			}
 		}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -1065,7 +1065,7 @@ public class Util
 	public static boolean getShouldShowArtistPicture(Context context)
 	{
 		SharedPreferences preferences = getPreferences();
-		boolean isOffline = ActiveServerProvider.Companion.isOffline(context);
+		boolean isOffline = ActiveServerProvider.Companion.isOffline();
 		boolean isId3Enabled = preferences.getBoolean(Constants.PREFERENCES_KEY_ID3_TAGS, false);
 		boolean shouldShowArtistPicture = preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_ARTIST_PICTURE, false);
 		return (!isOffline) && isId3Enabled && shouldShowArtistPicture;

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -50,6 +50,7 @@ import androidx.annotation.ColorInt;
 import androidx.preference.PreferenceManager;
 
 import org.moire.ultrasonic.R;
+import org.moire.ultrasonic.app.UApp;
 import org.moire.ultrasonic.data.ActiveServerProvider;
 import org.moire.ultrasonic.domain.*;
 import org.moire.ultrasonic.domain.MusicDirectory.Entry;
@@ -86,9 +87,6 @@ public class Util
 	public static final String CM_AVRCP_PLAYSTATE_CHANGED = "com.android.music.playstatechanged";
 	public static final String CM_AVRCP_METADATA_CHANGED = "com.android.music.metachanged";
 
-	private static boolean mediaButtonsRegisteredForUI;
-	private static boolean mediaButtonsRegisteredForService;
-
 	// Used by hexEncode()
 	private static final char[] HEX_DIGITS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 	private static Toast toast;
@@ -99,58 +97,63 @@ public class Util
 	{
 	}
 
-	public static boolean isScreenLitOnDownload(Context context)
+	// Retrieves an instance of the application Context
+	public static Context appContext() {
+		return UApp.Companion.applicationContext();
+	}
+
+	public static boolean isScreenLitOnDownload()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SCREEN_LIT_ON_DOWNLOAD, false);
 	}
 
-	public static RepeatMode getRepeatMode(Context context)
+	public static RepeatMode getRepeatMode()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return RepeatMode.valueOf(preferences.getString(Constants.PREFERENCES_KEY_REPEAT_MODE, RepeatMode.OFF.name()));
 	}
 
-	public static void setRepeatMode(Context context, RepeatMode repeatMode)
+	public static void setRepeatMode(RepeatMode repeatMode)
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		SharedPreferences.Editor editor = preferences.edit();
 		editor.putString(Constants.PREFERENCES_KEY_REPEAT_MODE, repeatMode.name());
 		editor.apply();
 	}
 
-	public static boolean isNotificationEnabled(Context context)
+	public static boolean isNotificationEnabled()
 	{
 		// After API26 foreground services must be used for music playback, and they must have a notification
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) return true;
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_NOTIFICATION, false);
 	}
 
-	public static boolean isNotificationAlwaysEnabled(Context context)
+	public static boolean isNotificationAlwaysEnabled()
 	{
 		// After API26 foreground services must be used for music playback, and they must have a notification
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) return true;
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_ALWAYS_SHOW_NOTIFICATION, false);
 	}
 
 	@SuppressWarnings({"BooleanMethodIsAlwaysInverted"}) // It is inverted for readability
-	public static boolean isLockScreenEnabled(Context context)
+	public static boolean isLockScreenEnabled()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_LOCK_SCREEN_CONTROLS, false);
 	}
 
-	public static String getTheme(Context context)
+	public static String getTheme()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getString(Constants.PREFERENCES_KEY_THEME, Constants.PREFERENCES_KEY_THEME_DARK);
 	}
 
 	public static void applyTheme(Context context)
 	{
-		String theme = Util.getTheme(context);
+		String theme = Util.getTheme();
 
 		if (Constants.PREFERENCES_KEY_THEME_DARK.equalsIgnoreCase(theme) || "fullscreen".equalsIgnoreCase(theme))
 		{
@@ -178,26 +181,26 @@ public class Util
 		}
 
 		boolean wifi = networkInfo.getType() == ConnectivityManager.TYPE_WIFI;
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(wifi ? Constants.PREFERENCES_KEY_MAX_BITRATE_WIFI : Constants.PREFERENCES_KEY_MAX_BITRATE_MOBILE, "0"));
 	}
 
-	public static int getPreloadCount(Context context)
+	public static int getPreloadCount()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		int preloadCount = Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_PRELOAD_COUNT, "-1"));
 		return preloadCount == -1 ? Integer.MAX_VALUE : preloadCount;
 	}
 
-	public static int getCacheSizeMB(Context context)
+	public static int getCacheSizeMB()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		int cacheSize = Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_CACHE_SIZE, "-1"));
 		return cacheSize == -1 ? Integer.MAX_VALUE : cacheSize;
 	}
 
-    public static SharedPreferences getPreferences(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context);
+    public static SharedPreferences getPreferences() {
+        return PreferenceManager.getDefaultSharedPreferences(appContext());
     }
 
 	/**
@@ -554,7 +557,7 @@ public class Util
 		boolean connected = networkInfo != null && networkInfo.isConnected();
 
 		boolean wifiConnected = connected && networkInfo.getType() == ConnectivityManager.TYPE_WIFI;
-		boolean wifiRequired = isWifiRequiredForDownload(context);
+		boolean wifiRequired = isWifiRequiredForDownload();
 
 		return connected && (!wifiRequired || wifiConnected);
 	}
@@ -564,34 +567,30 @@ public class Util
 		return Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState());
 	}
 
-	private static boolean isWifiRequiredForDownload(Context context)
+	private static boolean isWifiRequiredForDownload()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_WIFI_REQUIRED_FOR_DOWNLOAD, false);
 	}
 
-	public static boolean shouldDisplayBitrateWithArtist(Context context)
+	public static boolean shouldDisplayBitrateWithArtist()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_DISPLAY_BITRATE_WITH_ARTIST, true);
 	}
 
-	public static boolean shouldUseFolderForArtistName(Context context)
+	public static boolean shouldUseFolderForArtistName()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_USE_FOLDER_FOR_ALBUM_ARTIST, false);
 	}
 
-	public static boolean shouldShowTrackNumber(Context context)
+	public static boolean shouldShowTrackNumber()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_TRACK_NUMBER, false);
 	}
 
-	public static void info(Context context, int titleId, int messageId)
-	{
-		showDialog(context, android.R.drawable.ic_dialog_info, titleId, messageId);
-	}
 
 	private static void showDialog(Context context, int icon, int titleId, int messageId)
 	{
@@ -669,7 +668,7 @@ public class Util
 
 	public static int getScaledHeight(Bitmap bitmap, int width)
 	{
-		return getScaledHeight((double) bitmap.getHeight(), (double) bitmap.getWidth(), width);
+		return getScaledHeight(bitmap.getHeight(), bitmap.getWidth(), width);
 	}
 
 	public static Bitmap scaleBitmap(Bitmap bitmap, int size)
@@ -742,7 +741,7 @@ public class Util
 
 	public static void broadcastA2dpMetaDataChange(Context context, int playerPosition, DownloadFile currentPlaying, int listSize, int id)
 	{
-		if (!Util.getShouldSendBluetoothNotifications(context))
+		if (!Util.getShouldSendBluetoothNotifications())
 		{
 			return;
 		}
@@ -763,7 +762,7 @@ public class Util
 			avrcpIntent.putExtra("album_artist", "");
 			avrcpIntent.putExtra("album_artist_name", "");
 
-			if (Util.getShouldSendBluetoothAlbumArt(context))
+			if (Util.getShouldSendBluetoothAlbumArt())
 			{
 				avrcpIntent.putExtra("coverart", (Parcelable) null);
 				avrcpIntent.putExtra("cover", (Parcelable) null);
@@ -796,7 +795,7 @@ public class Util
 			avrcpIntent.putExtra("album_artist_name", artist);
 
 
-			if (Util.getShouldSendBluetoothAlbumArt(context))
+			if (Util.getShouldSendBluetoothAlbumArt())
 			{
 				File albumArtFile = FileUtil.getAlbumArtFile(context, song);
 				avrcpIntent.putExtra("coverart", albumArtFile.getAbsolutePath());
@@ -818,7 +817,7 @@ public class Util
 
 	public static void broadcastA2dpPlayStatusChange(Context context, PlayerState state, Entry currentSong, Integer listSize, Integer id, Integer playerPosition)
 	{
-		if (!Util.getShouldSendBluetoothNotifications(context))
+		if (!Util.getShouldSendBluetoothNotifications())
 		{
 			return;
 		}
@@ -852,7 +851,7 @@ public class Util
 			avrcpIntent.putExtra("album_artist", artist);
 			avrcpIntent.putExtra("album_artist_name", artist);
 
-			if (Util.getShouldSendBluetoothAlbumArt(context))
+			if (Util.getShouldSendBluetoothAlbumArt())
 			{
 				File albumArtFile = FileUtil.getAlbumArtFile(context, currentSong);
 				avrcpIntent.putExtra("coverart", albumArtFile.getAbsolutePath());
@@ -985,109 +984,102 @@ public class Util
 		return inSampleSize;
 	}
 
-	// TODO: Shouldn't this be used when making requests?
-	public static int getNetworkTimeout(Context context)
+	public static int getDefaultAlbums()
 	{
-		SharedPreferences preferences = getPreferences(context);
-		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_NETWORK_TIMEOUT, "15000"));
-	}
-
-	public static int getDefaultAlbums(Context context)
-	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_DEFAULT_ALBUMS, "5"));
 	}
 
-	public static int getMaxAlbums(Context context)
+	public static int getMaxAlbums()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_MAX_ALBUMS, "20"));
 	}
 
-	public static int getDefaultSongs(Context context)
+	public static int getDefaultSongs()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_DEFAULT_SONGS, "10"));
 	}
 
-	public static int getMaxSongs(Context context)
+	public static int getMaxSongs()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_MAX_SONGS, "25"));
 	}
 
-	public static int getMaxArtists(Context context)
+	public static int getMaxArtists()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_MAX_ARTISTS, "10"));
 	}
 
-	public static int getDefaultArtists(Context context)
+	public static int getDefaultArtists()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_DEFAULT_ARTISTS, "3"));
 	}
 
-	public static int getBufferLength(Context context)
+	public static int getBufferLength()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_BUFFER_LENGTH, "5"));
 	}
 
-	public static int getIncrementTime(Context context)
+	public static int getIncrementTime()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_INCREMENT_TIME, "5"));
 	}
 
-	public static boolean getMediaButtonsEnabled(Context context)
+	public static boolean getMediaButtonsEnabled()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_MEDIA_BUTTONS, true);
 	}
 
-	public static boolean getShowNowPlayingPreference(Context context)
+	public static boolean getShowNowPlayingPreference()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_NOW_PLAYING, true);
 	}
 
-	public static boolean getGaplessPlaybackPreference(Context context)
+	public static boolean getGaplessPlaybackPreference()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_GAPLESS_PLAYBACK, false);
 	}
 
-	public static boolean getShouldTransitionOnPlaybackPreference(Context context)
+	public static boolean getShouldTransitionOnPlaybackPreference()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_DOWNLOAD_TRANSITION, true);
 	}
 
-	public static boolean getShouldUseId3Tags(Context context)
+	public static boolean getShouldUseId3Tags()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_ID3_TAGS, false);
 	}
 
 	public static boolean getShouldShowArtistPicture(Context context)
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		boolean isOffline = ActiveServerProvider.Companion.isOffline(context);
 		boolean isId3Enabled = preferences.getBoolean(Constants.PREFERENCES_KEY_ID3_TAGS, false);
 		boolean shouldShowArtistPicture = preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_ARTIST_PICTURE, false);
 		return (!isOffline) && isId3Enabled && shouldShowArtistPicture;
 	}
 
-	public static int getChatRefreshInterval(Context context)
+	public static int getChatRefreshInterval()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_CHAT_REFRESH_INTERVAL, "5000"));
 	}
 
-	public static int getDirectoryCacheTime(Context context)
+	public static int getDirectoryCacheTime()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_DIRECTORY_CACHE_TIME, "300"));
 	}
 
@@ -1102,27 +1094,27 @@ public class Util
 		return formatTotalDuration(totalDuration, false);
 	}
 
-	public static boolean getShouldClearPlaylist(Context context)
+	public static boolean getShouldClearPlaylist()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_CLEAR_PLAYLIST, false);
 	}
 
-	public static boolean getShouldSortByDisc(Context context)
+	public static boolean getShouldSortByDisc()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_DISC_SORT, false);
 	}
 
-	public static boolean getShouldClearBookmark(Context context)
+	public static boolean getShouldClearBookmark()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_CLEAR_BOOKMARK, false);
 	}
 
-	public static boolean getSingleButtonPlayPause(Context context)
+	public static boolean getSingleButtonPlayPause()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SINGLE_BUTTON_PLAY_PAUSE, false);
 	}
 
@@ -1155,9 +1147,9 @@ public class Util
 		else return minutes > 0 ? String.format(Locale.getDefault(), "%d:%02d", minutes, seconds) : String.format(Locale.getDefault(), "0:%02d", seconds);
 	}
 
-	public static VideoPlayerType getVideoPlayerType(Context context)
+	public static VideoPlayerType getVideoPlayerType()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return VideoPlayerType.forKey(preferences.getString(Constants.PREFERENCES_KEY_VIDEO_PLAYER, VideoPlayerType.MX.getKey()));
 	}
 
@@ -1232,51 +1224,51 @@ public class Util
 	}
 
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted") // Inverted for readability
-	public static boolean getShouldSendBluetoothNotifications(Context context)
+	public static boolean getShouldSendBluetoothNotifications()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SEND_BLUETOOTH_NOTIFICATIONS, true);
 	}
 
-	public static boolean getShouldSendBluetoothAlbumArt(Context context)
+	public static boolean getShouldSendBluetoothAlbumArt()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SEND_BLUETOOTH_ALBUM_ART, true);
 	}
 
-	public static int getViewRefreshInterval(Context context)
+	public static int getViewRefreshInterval()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_VIEW_REFRESH, "1000"));
 	}
 
-	public static boolean getShouldAskForShareDetails(Context context)
+	public static boolean getShouldAskForShareDetails()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_ASK_FOR_SHARE_DETAILS, true);
 	}
 
-	public static String getDefaultShareDescription(Context context)
+	public static String getDefaultShareDescription()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getString(Constants.PREFERENCES_KEY_DEFAULT_SHARE_DESCRIPTION, "");
 	}
 
 	public static String getShareGreeting(Context context)
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getString(Constants.PREFERENCES_KEY_DEFAULT_SHARE_GREETING, String.format(context.getResources().getString(R.string.share_default_greeting), context.getResources().getString(R.string.common_appname)));
 	}
 
-	public static String getDefaultShareExpiration(Context context)
+	public static String getDefaultShareExpiration()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getString(Constants.PREFERENCES_KEY_DEFAULT_SHARE_EXPIRATION, "0");
 	}
 
 	public static long getDefaultShareExpirationInMillis(Context context)
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		String preference = preferences.getString(Constants.PREFERENCES_KEY_DEFAULT_SHARE_EXPIRATION, "0");
 
 		String[] split = PATTERN.split(preference);
@@ -1294,33 +1286,33 @@ public class Util
 		return 0;
 	}
 
-	public static void setShouldAskForShareDetails(Context context, boolean shouldAskForShareDetails)
+	public static void setShouldAskForShareDetails(boolean shouldAskForShareDetails)
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		SharedPreferences.Editor editor = preferences.edit();
 		editor.putBoolean(Constants.PREFERENCES_KEY_ASK_FOR_SHARE_DETAILS, shouldAskForShareDetails);
 		editor.apply();
 	}
 
-	public static void setDefaultShareExpiration(Context context, String defaultShareExpiration)
+	public static void setDefaultShareExpiration(String defaultShareExpiration)
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		SharedPreferences.Editor editor = preferences.edit();
 		editor.putString(Constants.PREFERENCES_KEY_DEFAULT_SHARE_EXPIRATION, defaultShareExpiration);
 		editor.apply();
 	}
 
-	public static void setDefaultShareDescription(Context context, String defaultShareDescription)
+	public static void setDefaultShareDescription(String defaultShareDescription)
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		SharedPreferences.Editor editor = preferences.edit();
 		editor.putString(Constants.PREFERENCES_KEY_DEFAULT_SHARE_DESCRIPTION, defaultShareDescription);
 		editor.apply();
 	}
 
-	public static boolean getShouldShowAllSongsByArtist(Context context)
+	public static boolean getShouldShowAllSongsByArtist()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_SHOW_ALL_SONGS_BY_ARTIST, false);
 	}
 
@@ -1331,18 +1323,10 @@ public class Util
 		context.sendBroadcast(scanFileIntent);
 	}
 
-	public static int getImageLoaderConcurrency(Context context)
+	public static int getImageLoaderConcurrency()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return Integer.parseInt(preferences.getString(Constants.PREFERENCES_KEY_IMAGE_LOADER_CONCURRENCY, "5"));
-	}
-
-	public static @ColorInt int getColorFromAttribute(Context context, int resId)
-	{
-		TypedValue typedValue = new TypedValue();
-		Resources.Theme theme = context.getTheme();
-		theme.resolveAttribute(resId, typedValue, true);
-		return typedValue.data;
 	}
 
 	public static int getResourceFromAttribute(Context context, int resId)
@@ -1353,9 +1337,9 @@ public class Util
 		return typedValue.resourceId;
 	}
 
-	public static boolean isFirstRun(Context context)
+	public static boolean isFirstRun()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		boolean firstExecuted = preferences.getBoolean(Constants.PREFERENCES_KEY_FIRST_RUN_EXECUTED, false);
 		if (firstExecuted) return false;
 		SharedPreferences.Editor editor = preferences.edit();
@@ -1364,21 +1348,21 @@ public class Util
 		return true;
 	}
 
-	public static int getResumeOnBluetoothDevice(Context context)
+	public static int getResumeOnBluetoothDevice()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getInt(Constants.PREFERENCES_KEY_RESUME_ON_BLUETOOTH_DEVICE, Constants.PREFERENCE_VALUE_DISABLED);
 	}
 
-	public static int getPauseOnBluetoothDevice(Context context)
+	public static int getPauseOnBluetoothDevice()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getInt(Constants.PREFERENCES_KEY_PAUSE_ON_BLUETOOTH_DEVICE, Constants.PREFERENCE_VALUE_A2DP);
 	}
 
-	public static boolean getDebugLogToFile(Context context)
+	public static boolean getDebugLogToFile()
 	{
-		SharedPreferences preferences = getPreferences(context);
+		SharedPreferences preferences = getPreferences();
 		return preferences.getBoolean(Constants.PREFERENCES_KEY_DEBUG_LOG_TO_FILE, false);
 	}
 

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/Util.java
@@ -46,7 +46,6 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
-import androidx.annotation.ColorInt;
 import androidx.preference.PreferenceManager;
 
 import org.moire.ultrasonic.R;
@@ -725,7 +724,7 @@ public class Util
 			intent.putExtra("artist", song.getArtist());
 			intent.putExtra("album", song.getAlbum());
 
-			File albumArtFile = FileUtil.getAlbumArtFile(context, song);
+			File albumArtFile = FileUtil.getAlbumArtFile(song);
 			intent.putExtra("coverart", albumArtFile.getAbsolutePath());
 		}
 		else
@@ -797,7 +796,7 @@ public class Util
 
 			if (Util.getShouldSendBluetoothAlbumArt())
 			{
-				File albumArtFile = FileUtil.getAlbumArtFile(context, song);
+				File albumArtFile = FileUtil.getAlbumArtFile(song);
 				avrcpIntent.putExtra("coverart", albumArtFile.getAbsolutePath());
 				avrcpIntent.putExtra("cover", albumArtFile.getAbsolutePath());
 			}
@@ -853,7 +852,7 @@ public class Util
 
 			if (Util.getShouldSendBluetoothAlbumArt())
 			{
-				File albumArtFile = FileUtil.getAlbumArtFile(context, currentSong);
+				File albumArtFile = FileUtil.getAlbumArtFile(currentSong);
 				avrcpIntent.putExtra("coverart", albumArtFile.getAbsolutePath());
 				avrcpIntent.putExtra("cover", albumArtFile.getAbsolutePath());
 			}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/VideoPlayerType.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/VideoPlayerType.java
@@ -79,7 +79,7 @@ public enum VideoPlayerType
 						Intent intent = new Intent(Intent.ACTION_VIEW);
 						intent.setPackage(installedPro ? PACKAGE_NAME_MX_PRO : PACKAGE_NAME_MX_AD);
 						intent.putExtra("title", entry.getTitle());
-						intent.setDataAndType(Uri.parse(MusicServiceFactory.getMusicService(context).getVideoUrl(context, entry.getId(), false)), "video/*");
+						intent.setDataAndType(Uri.parse(MusicServiceFactory.getMusicService().getVideoUrl(context, entry.getId(), false)), "video/*");
 						context.startActivity(intent);
 					}
 				}
@@ -91,7 +91,7 @@ public enum VideoPlayerType
 				public void playVideo(Context context, MusicDirectory.Entry entry) throws Exception
 				{
 					Intent intent = new Intent(Intent.ACTION_VIEW);
-					intent.setData(Uri.parse(MusicServiceFactory.getMusicService(context).getVideoUrl(context, entry.getId(), true)));
+					intent.setData(Uri.parse(MusicServiceFactory.getMusicService().getVideoUrl(context, entry.getId(), true)));
 					context.startActivity(intent);
 				}
 			},
@@ -102,7 +102,7 @@ public enum VideoPlayerType
 				public void playVideo(Context context, MusicDirectory.Entry entry) throws Exception
 				{
 					Intent intent = new Intent(Intent.ACTION_VIEW);
-					intent.setDataAndType(Uri.parse(MusicServiceFactory.getMusicService(context).getVideoUrl(context, entry.getId(), false)), "video/*");
+					intent.setDataAndType(Uri.parse(MusicServiceFactory.getMusicService().getVideoUrl(context, entry.getId(), false)), "video/*");
 					context.startActivity(intent);
 				}
 			};

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
@@ -158,11 +158,11 @@ public class AlbumView extends UpdateView
 							{
 								if (!isStarred)
 								{
-									musicService.star(!useId3 ? id : null, useId3 ? id : null, null, getContext());
+									musicService.star(!useId3 ? id : null, useId3 ? id : null, null);
 								}
 								else
 								{
-									musicService.unstar(!useId3 ? id : null, useId3 ? id : null, null, getContext());
+									musicService.unstar(!useId3 ? id : null, useId3 ? id : null, null);
 								}
 							}
 							catch (Exception e)

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
@@ -54,7 +54,7 @@ public class AlbumView extends UpdateView
 		this.context = context;
 		this.imageLoader = imageLoader;
 
-		String theme = Util.getTheme(context);
+		String theme = Util.getTheme();
 		boolean themesMatch = theme.equals(AlbumView.theme);
 		AlbumView.theme = theme;
 
@@ -152,7 +152,7 @@ public class AlbumView extends UpdateView
 						@Override
 						public void run()
 						{
-							boolean useId3 = Util.getShouldUseId3Tags(getContext());
+							boolean useId3 = Util.getShouldUseId3Tags();
 
 							try
 							{

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
@@ -121,7 +121,7 @@ public class AlbumView extends UpdateView
 		viewHolder.artist.setVisibility(artist == null ? View.GONE : View.VISIBLE);
 		viewHolder.star.setImageDrawable(starred ? starDrawable : starHollowDrawable);
 
-		if (ActiveServerProvider.Companion.isOffline(this.context) || "-1".equals(album.getId()))
+		if (ActiveServerProvider.Companion.isOffline() || "-1".equals(album.getId()))
 		{
 			viewHolder.star.setVisibility(View.GONE);
 		}

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/AlbumView.java
@@ -146,7 +146,7 @@ public class AlbumView extends UpdateView
 						album.setStarred(false);
 					}
 
-                    final MusicService musicService = MusicServiceFactory.getMusicService(view.getContext());
+                    final MusicService musicService = MusicServiceFactory.getMusicService();
 					new Thread(new Runnable()
 					{
 						@Override

--- a/ultrasonic/src/main/java/org/moire/ultrasonic/view/UpdateView.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/view/UpdateView.java
@@ -116,7 +116,7 @@ public class UpdateView extends LinearLayout
 					Timber.w(x, "Error when updating song views.");
 				}
 
-				uiHandler.postDelayed(updateRunnable, Util.getViewRefreshInterval(context));
+				uiHandler.postDelayed(updateRunnable, Util.getViewRefreshInterval());
 			}
 		};
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
@@ -368,7 +368,7 @@ class NavigationActivity : AppCompatActivity() {
     }
 
     private fun setMenuForServerSetting() {
-        val visibility = !isOffline(this)
+        val visibility = !isOffline()
         chatMenuItem?.isVisible = visibility
         bookmarksMenuItem?.isVisible = visibility
         sharesMenuItem?.isVisible = visibility

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
@@ -301,7 +301,7 @@ class NavigationActivity : AppCompatActivity() {
             val editor = preferences.edit()
             editor.putString(
                 Constants.PREFERENCES_KEY_CACHE_LOCATION,
-                FileUtil.getDefaultMusicDirectory(this).path
+                FileUtil.getDefaultMusicDirectory().path
             )
             editor.apply()
         }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
@@ -142,7 +142,7 @@ class NavigationActivity : AppCompatActivity() {
         }
 
         // Determine first run and migrate server settings to DB as early as possible
-        var showWelcomeScreen = Util.isFirstRun(this)
+        var showWelcomeScreen = Util.isFirstRun()
         val areServersMigrated: Boolean = serverSettingsModel.migrateFromPreferences()
 
         // If there are any servers in the DB, do not show the welcome screen
@@ -296,7 +296,7 @@ class NavigationActivity : AppCompatActivity() {
 
     private fun loadSettings() {
         PreferenceManager.setDefaultValues(this, R.xml.settings, false)
-        val preferences = Util.getPreferences(this)
+        val preferences = Util.getPreferences()
         if (!preferences.contains(Constants.PREFERENCES_KEY_CACHE_LOCATION)) {
             val editor = preferences.edit()
             editor.putString(
@@ -336,7 +336,7 @@ class NavigationActivity : AppCompatActivity() {
     }
 
     private fun showNowPlaying() {
-        if (!Util.getShowNowPlayingPreference(this)) {
+        if (!Util.getShowNowPlayingPreference()) {
             hideNowPlaying()
             return
         }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/app/UApp.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/app/UApp.kt
@@ -36,7 +36,7 @@ class UApp : MultiDexApplication() {
             Timber.plant(DebugTree())
         }
         if (Util.getDebugLogToFile()) {
-            FileLoggerTree.plantToTimberForest(this)
+            FileLoggerTree.plantToTimberForest()
         }
 
         startKoin {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/app/UApp.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/app/UApp.kt
@@ -1,5 +1,6 @@
 package org.moire.ultrasonic.app
 
+import android.content.Context
 import androidx.multidex.MultiDexApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
@@ -21,15 +22,20 @@ import timber.log.Timber.DebugTree
 /**
  * The Main class of the Application
  */
-@Suppress("unused")
+
 class UApp : MultiDexApplication() {
+
+    init {
+        instance = this
+    }
+
     override fun onCreate() {
         super.onCreate()
 
         if (BuildConfig.DEBUG) {
             Timber.plant(DebugTree())
         }
-        if (Util.getDebugLogToFile(this)) {
+        if (Util.getDebugLogToFile()) {
             FileLoggerTree.plantToTimberForest(this)
         }
 
@@ -47,6 +53,14 @@ class UApp : MultiDexApplication() {
                 musicServiceModule,
                 mediaPlayerModule
             )
+        }
+    }
+
+    companion object {
+        private var instance: UApp? = null
+
+        fun applicationContext(): Context {
+            return instance!!.applicationContext
         }
     }
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
@@ -1,12 +1,12 @@
 package org.moire.ultrasonic.data
 
-import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.moire.ultrasonic.R
+import org.moire.ultrasonic.app.UApp
 import org.moire.ultrasonic.service.MusicServiceFactory.resetMusicService
 import org.moire.ultrasonic.util.Constants
 import org.moire.ultrasonic.util.Util
@@ -17,8 +17,7 @@ import timber.log.Timber
  * It caches the settings read up from the DB to improve performance.
  */
 class ActiveServerProvider(
-    private val repository: ServerSettingDao,
-    private val context: Context
+    private val repository: ServerSettingDao
 ) {
     private var cachedServer: ServerSetting? = null
 
@@ -27,7 +26,7 @@ class ActiveServerProvider(
      * @return The Active Server Settings
      */
     fun getActiveServer(): ServerSetting {
-        val serverId = getActiveServerId(context)
+        val serverId = getActiveServerId()
 
         if (serverId > 0) {
             if (cachedServer != null && cachedServer!!.id == serverId) return cachedServer!!
@@ -44,13 +43,13 @@ class ActiveServerProvider(
             }
 
             if (cachedServer != null) return cachedServer!!
-            setActiveServerId(context, 0)
+            setActiveServerId(0)
         }
 
         return ServerSetting(
             id = -1,
             index = 0,
-            name = context.getString(R.string.main_offline),
+            name = UApp.applicationContext().getString(R.string.main_offline),
             url = "http://localhost",
             userName = "",
             password = "",
@@ -70,13 +69,13 @@ class ActiveServerProvider(
         Timber.d("setActiveServerByIndex $index")
         if (index < 1) {
             // Offline mode is selected
-            setActiveServerId(context, 0)
+            setActiveServerId(0)
             return
         }
 
         GlobalScope.launch(Dispatchers.IO) {
             val serverId = repository.findByIndex(index)?.id ?: 0
-            setActiveServerId(context, serverId)
+            setActiveServerId(serverId)
         }
     }
 
@@ -132,14 +131,14 @@ class ActiveServerProvider(
          * Queries if the Active Server is the "Offline" mode of Ultrasonic
          * @return True, if the "Offline" mode is selected
          */
-        fun isOffline(context: Context?): Boolean {
-            return context == null || getActiveServerId(context) < 1
+        fun isOffline(): Boolean {
+            return getActiveServerId() < 1
         }
 
         /**
          * Queries the Id of the Active Server
          */
-        fun getActiveServerId(context: Context): Int {
+        fun getActiveServerId(): Int {
             val preferences = Util.getPreferences()
             return preferences.getInt(Constants.PREFERENCES_KEY_SERVER_INSTANCE, -1)
         }
@@ -147,7 +146,7 @@ class ActiveServerProvider(
         /**
          * Sets the Id of the Active Server
          */
-        fun setActiveServerId(context: Context, serverId: Int) {
+        fun setActiveServerId(serverId: Int) {
             resetMusicService()
 
             val preferences = Util.getPreferences()
@@ -159,8 +158,8 @@ class ActiveServerProvider(
         /**
          * Queries if Scrobbling is enabled
          */
-        fun isScrobblingEnabled(context: Context): Boolean {
-            if (isOffline(context)) {
+        fun isScrobblingEnabled(): Boolean {
+            if (isOffline()) {
                 return false
             }
             val preferences = Util.getPreferences()
@@ -170,8 +169,8 @@ class ActiveServerProvider(
         /**
          * Queries if Server Scaling is enabled
          */
-        fun isServerScalingEnabled(context: Context): Boolean {
-            if (isOffline(context)) {
+        fun isServerScalingEnabled(): Boolean {
+            if (isOffline()) {
                 return false
             }
             val preferences = Util.getPreferences()

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ActiveServerProvider.kt
@@ -140,7 +140,7 @@ class ActiveServerProvider(
          * Queries the Id of the Active Server
          */
         fun getActiveServerId(context: Context): Int {
-            val preferences = Util.getPreferences(context)
+            val preferences = Util.getPreferences()
             return preferences.getInt(Constants.PREFERENCES_KEY_SERVER_INSTANCE, -1)
         }
 
@@ -150,7 +150,7 @@ class ActiveServerProvider(
         fun setActiveServerId(context: Context, serverId: Int) {
             resetMusicService()
 
-            val preferences = Util.getPreferences(context)
+            val preferences = Util.getPreferences()
             val editor = preferences.edit()
             editor.putInt(Constants.PREFERENCES_KEY_SERVER_INSTANCE, serverId)
             editor.apply()
@@ -163,7 +163,7 @@ class ActiveServerProvider(
             if (isOffline(context)) {
                 return false
             }
-            val preferences = Util.getPreferences(context)
+            val preferences = Util.getPreferences()
             return preferences.getBoolean(Constants.PREFERENCES_KEY_SCROBBLE, false)
         }
 
@@ -174,7 +174,7 @@ class ActiveServerProvider(
             if (isOffline(context)) {
                 return false
             }
-            val preferences = Util.getPreferences(context)
+            val preferences = Util.getPreferences()
             return preferences.getBoolean(Constants.PREFERENCES_KEY_SERVER_SCALING, false)
         }
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/AppPermanentStorageModule.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/AppPermanentStorageModule.kt
@@ -16,7 +16,7 @@ const val SP_NAME = "Default_SP"
  * This Koin module contains registration of classes related to permanent storage
  */
 val appPermanentStorage = module {
-    single(named(SP_NAME)) { Util.getPreferences(androidContext()) }
+    single(named(SP_NAME)) { Util.getPreferences() }
 
     single {
         Room.databaseBuilder(

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/ApplicationModule.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/ApplicationModule.kt
@@ -12,7 +12,7 @@ import org.moire.ultrasonic.util.ThemeChangedEventDistributor
  * This Koin module contains the registration of general classes needed for Ultrasonic
  */
 val applicationModule = module {
-    single { ActiveServerProvider(get(), androidContext()) }
+    single { ActiveServerProvider(get()) }
     single { ImageLoaderProvider(androidContext()) }
     single { PermissionUtil(androidContext()) }
     single { NowPlayingEventDistributor() }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/MusicServiceModule.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/MusicServiceModule.kt
@@ -36,7 +36,7 @@ internal const val OFFLINE_MUSIC_SERVICE = "OfflineMusicService"
 val musicServiceModule = module {
 
     single(named("ServerInstance")) {
-        return@single ActiveServerProvider.getActiveServerId(androidContext())
+        return@single ActiveServerProvider.getActiveServerId()
     }
 
     single(named("ServerID")) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/MusicServiceModule.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/MusicServiceModule.kt
@@ -81,7 +81,7 @@ val musicServiceModule = module {
 
     single { SubsonicImageLoader(androidContext(), get()) }
 
-    viewModel { ArtistListModel(get(), androidContext()) }
+    viewModel { ArtistListModel(get()) }
 
     single { DownloadHandler(get(), get()) }
     single { NetworkAndStorageChecker(androidContext()) }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
@@ -18,7 +18,6 @@
  */
 package org.moire.ultrasonic.fragment
 
-import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import androidx.lifecycle.LiveData
@@ -40,8 +39,7 @@ import org.moire.ultrasonic.util.Util
  * Provides ViewModel which contains the list of available Artists
  */
 class ArtistListModel(
-    private val activeServerProvider: ActiveServerProvider,
-    private val context: Context
+    private val activeServerProvider: ActiveServerProvider
 ) : ViewModel() {
     private val musicFolders: MutableLiveData<List<MusicFolder>> = MutableLiveData()
     private val artists: MutableLiveData<List<Artist>> = MutableLiveData()
@@ -93,7 +91,7 @@ class ArtistListModel(
 
                 val result = if (!isOffline && useId3Tags)
                     musicService.getArtists(refresh)
-                else musicService.getIndexes(musicFolderId, refresh, context)
+                else musicService.getIndexes(musicFolderId, refresh)
 
                 val retrievedArtists: MutableList<Artist> =
                     ArrayList(result.shortcuts.size + result.artists.size)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
@@ -80,7 +80,7 @@ class ArtistListModel(
         withContext(Dispatchers.IO) {
             val musicService = MusicServiceFactory.getMusicService(context)
             val isOffline = ActiveServerProvider.isOffline(context)
-            val useId3Tags = Util.getShouldUseId3Tags(context)
+            val useId3Tags = Util.getShouldUseId3Tags()
 
             try {
                 if (!isOffline && !useId3Tags) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
@@ -79,7 +79,7 @@ class ArtistListModel(
     private suspend fun loadFromServer(refresh: Boolean, swipe: SwipeRefreshLayout) =
         withContext(Dispatchers.IO) {
             val musicService = MusicServiceFactory.getMusicService(context)
-            val isOffline = ActiveServerProvider.isOffline(context)
+            val isOffline = ActiveServerProvider.isOffline()
             val useId3Tags = Util.getShouldUseId3Tags()
 
             try {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
@@ -85,14 +85,14 @@ class ArtistListModel(
             try {
                 if (!isOffline && !useId3Tags) {
                     musicFolders.postValue(
-                        musicService.getMusicFolders(refresh, context)
+                        musicService.getMusicFolders(refresh)
                     )
                 }
 
                 val musicFolderId = activeServerProvider.getActiveServer().musicFolderId
 
                 val result = if (!isOffline && useId3Tags)
-                    musicService.getArtists(refresh, context)
+                    musicService.getArtists(refresh)
                 else musicService.getIndexes(musicFolderId, refresh, context)
 
                 val retrievedArtists: MutableList<Artist> =

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistListModel.kt
@@ -78,7 +78,7 @@ class ArtistListModel(
 
     private suspend fun loadFromServer(refresh: Boolean, swipe: SwipeRefreshLayout) =
         withContext(Dispatchers.IO) {
-            val musicService = MusicServiceFactory.getMusicService(context)
+            val musicService = MusicServiceFactory.getMusicService()
             val isOffline = ActiveServerProvider.isOffline()
             val useId3Tags = Util.getShouldUseId3Tags()
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistRowAdapter.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/ArtistRowAdapter.kt
@@ -156,7 +156,7 @@ class ArtistRowAdapter(
         inflater.inflate(R.menu.select_artist_context, popup.menu)
 
         val downloadMenuItem = popup.menu.findItem(R.id.artist_menu_download)
-        downloadMenuItem?.isVisible = !isOffline(view.context)
+        downloadMenuItem?.isVisible = !isOffline()
 
         popup.setOnMenuItemClickListener { menuItem ->
             onContextMenuClick(menuItem, artistList[position])

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
@@ -298,7 +298,7 @@ class SelectAlbumFragment : Fragment() {
                 model.getRandom(albumListSize)
             } else {
                 setTitle(name)
-                if (!isOffline(activity) && Util.getShouldUseId3Tags(activity)) {
+                if (!isOffline(activity) && Util.getShouldUseId3Tags()) {
                     if (isAlbum) {
                         model.getAlbum(refresh, id, name, parentId)
                     } else {
@@ -710,7 +710,7 @@ class SelectAlbumFragment : Fragment() {
     private fun updateInterfaceWithEntries(musicDirectory: MusicDirectory) {
         val entries = musicDirectory.getChildren()
 
-        if (model.currentDirectoryIsSortable && Util.getShouldSortByDisc(context)) {
+        if (model.currentDirectoryIsSortable && Util.getShouldSortByDisc()) {
             Collections.sort(entries, EntryByDiscAndTrackComparator())
         }
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumFragment.kt
@@ -131,7 +131,7 @@ class SelectAlbumFragment : Fragment() {
         selectFolderHeader = SelectMusicFolderView(
             requireContext(), view as ViewGroup
         ) { selectedFolderId ->
-            if (!isOffline(context)) {
+            if (!isOffline()) {
                 val serverSettingsModel: ServerSettingsModel by viewModel()
                 val currentSetting = activeServerProvider.getActiveServer()
                 currentSetting.musicFolderId = selectedFolderId
@@ -298,7 +298,7 @@ class SelectAlbumFragment : Fragment() {
                 model.getRandom(albumListSize)
             } else {
                 setTitle(name)
-                if (!isOffline(activity) && Util.getShouldUseId3Tags()) {
+                if (!isOffline() && Util.getShouldUseId3Tags()) {
                     if (isAlbum) {
                         model.getAlbum(refresh, id, name, parentId)
                     } else {
@@ -327,12 +327,12 @@ class SelectAlbumFragment : Fragment() {
         shareButton = menu.findItem(R.id.menu_item_share)
 
         if (shareButton != null) {
-            shareButton!!.isVisible = !isOffline(context)
+            shareButton!!.isVisible = !isOffline()
         }
 
         val downloadMenuItem = menu.findItem(R.id.album_menu_download)
         if (downloadMenuItem != null) {
-            downloadMenuItem.isVisible = !isOffline(context)
+            downloadMenuItem.isVisible = !isOffline()
         }
     }
 
@@ -551,12 +551,12 @@ class SelectAlbumFragment : Fragment() {
         playNowButton!!.visibility = if (enabled) View.VISIBLE else View.GONE
         playNextButton!!.visibility = if (enabled) View.VISIBLE else View.GONE
         playLastButton!!.visibility = if (enabled) View.VISIBLE else View.GONE
-        pinButton!!.visibility = if (enabled && !isOffline(context) && selection.size > pinnedCount)
+        pinButton!!.visibility = if (enabled && !isOffline() && selection.size > pinnedCount)
             View.VISIBLE
         else
             View.GONE
         unpinButton!!.visibility = if (enabled && unpinEnabled) View.VISIBLE else View.GONE
-        downloadButton!!.visibility = if (enabled && !deleteEnabled && !isOffline(context))
+        downloadButton!!.visibility = if (enabled && !deleteEnabled && !isOffline())
             View.VISIBLE
         else
             View.GONE
@@ -799,7 +799,7 @@ class SelectAlbumFragment : Fragment() {
         )
 
         playAllButtonVisible = !(isAlbumList || entries.isEmpty()) && !allVideos
-        shareButtonVisible = !isOffline(context) && songCount > 0
+        shareButtonVisible = !isOffline() && songCount > 0
 
         albumListView!!.removeHeaderView(emptyView!!)
         if (entries.isEmpty()) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
@@ -42,7 +42,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
         withContext(Dispatchers.IO) {
             if (!ActiveServerProvider.isOffline(context)) {
                 val musicService = MusicServiceFactory.getMusicService(context)
-                musicFolders.postValue(musicService.getMusicFolders(refresh, context))
+                musicFolders.postValue(musicService.getMusicFolders(refresh))
             }
         }
     }
@@ -131,7 +131,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
             var root = MusicDirectory()
 
-            val musicDirectory = service.getArtist(id, name, refresh, context)
+            val musicDirectory = service.getArtist(id, name, refresh)
 
             if (Util.getShouldShowAllSongsByArtist() &&
                 musicDirectory.findChild(allSongsId) == null &&
@@ -168,12 +168,12 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
                 val root = MusicDirectory()
 
                 val songs: MutableCollection<MusicDirectory.Entry> = LinkedList()
-                val artist = service.getArtist(parentId, "", false, context)
+                val artist = service.getArtist(parentId, "", false)
 
                 for ((id1) in artist.getChildren()) {
                     if (allSongsId != id1) {
                         val albumDirectory = service.getAlbum(
-                            id1, "", false, context
+                            id1, "", false
                         )
 
                         for (song in albumDirectory.getChildren()) {
@@ -191,7 +191,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
                 }
                 root
             } else {
-                service.getAlbum(id, name, refresh, context)
+                service.getAlbum(id, name, refresh)
             }
             currentDirectory.postValue(musicDirectory)
         }
@@ -211,12 +211,11 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
             val service = MusicServiceFactory.getMusicService(context)
             val musicDirectory: MusicDirectory
-            val context = context
 
             if (Util.getShouldUseId3Tags()) {
-                musicDirectory = Util.getSongsFromSearchResult(service.getStarred2(context))
+                musicDirectory = Util.getSongsFromSearchResult(service.starred2)
             } else {
-                musicDirectory = Util.getSongsFromSearchResult(service.getStarred(context))
+                musicDirectory = Util.getSongsFromSearchResult(service.starred)
             }
 
             currentDirectory.postValue(musicDirectory)
@@ -303,12 +302,12 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
             if (Util.getShouldUseId3Tags()) {
                 musicDirectory = service.getAlbumList2(
                     albumListType, size,
-                    offset, musicFolderId, context
+                    offset, musicFolderId
                 )
             } else {
                 musicDirectory = service.getAlbumList(
                     albumListType, size,
-                    offset, musicFolderId, context
+                    offset, musicFolderId
                 )
             }
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
@@ -61,7 +61,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
             if (allSongsId == id) {
                 val musicDirectory = service.getMusicDirectory(
-                    parentId, name, refresh, context
+                    parentId, name, refresh
                 )
 
                 val songs: MutableList<MusicDirectory.Entry> = LinkedList()
@@ -73,7 +73,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
                     }
                 }
             } else {
-                val musicDirectory = service.getMusicDirectory(id, name, refresh, context)
+                val musicDirectory = service.getMusicDirectory(id, name, refresh)
 
                 if (Util.getShouldShowAllSongsByArtist() &&
                     musicDirectory.findChild(allSongsId) == null &&
@@ -117,7 +117,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
             var root: MusicDirectory
 
             if (allSongsId != id1) {
-                root = service.getMusicDirectory(id1, title, false, context)
+                root = service.getMusicDirectory(id1, title, false)
 
                 getSongsRecursively(root, songs)
             }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
@@ -41,7 +41,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     suspend fun getMusicFolders(refresh: Boolean) {
         withContext(Dispatchers.IO) {
             if (!ActiveServerProvider.isOffline()) {
-                val musicService = MusicServiceFactory.getMusicService(context)
+                val musicService = MusicServiceFactory.getMusicService()
                 musicFolders.postValue(musicService.getMusicFolders(refresh))
             }
         }
@@ -55,7 +55,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     ) {
         withContext(Dispatchers.IO) {
 
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
 
             var root = MusicDirectory()
 
@@ -105,7 +105,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
         parent: MusicDirectory,
         songs: MutableList<MusicDirectory.Entry>
     ) {
-        val service = MusicServiceFactory.getMusicService(context)
+        val service = MusicServiceFactory.getMusicService()
 
         for (song in parent.getChildren(includeDirs = false, includeFiles = true)) {
             if (!song.isVideo && !song.isDirectory) {
@@ -127,7 +127,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     suspend fun getArtist(refresh: Boolean, id: String?, name: String?) {
 
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
 
             var root = MusicDirectory()
 
@@ -160,7 +160,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
         withContext(Dispatchers.IO) {
 
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
 
             val musicDirectory: MusicDirectory
 
@@ -199,7 +199,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
     suspend fun getSongsForGenre(genre: String, count: Int, offset: Int) {
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             val musicDirectory = service.getSongsByGenre(genre, count, offset, context)
             songsForGenre.postValue(musicDirectory)
         }
@@ -209,7 +209,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
         withContext(Dispatchers.IO) {
 
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             val musicDirectory: MusicDirectory
 
             if (Util.getShouldUseId3Tags()) {
@@ -226,7 +226,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
         showHeader = false
 
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             currentDirectory.postValue(service.getVideos(refresh, context))
         }
     }
@@ -234,7 +234,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     suspend fun getRandom(size: Int) {
 
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             val musicDirectory = service.getRandomSongs(size, context)
 
             currentDirectoryIsSortable = false
@@ -245,7 +245,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     suspend fun getPlaylist(playlistId: String, playlistName: String?) {
 
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             val musicDirectory = service.getPlaylist(playlistId, playlistName, context)
 
             currentDirectory.postValue(musicDirectory)
@@ -255,7 +255,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     suspend fun getPodcastEpisodes(podcastChannelId: String) {
 
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             val musicDirectory = service.getPodcastEpisodes(podcastChannelId, context)
             currentDirectory.postValue(musicDirectory)
         }
@@ -264,7 +264,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     suspend fun getShare(shareId: String) {
 
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             val musicDirectory = MusicDirectory()
 
             val shares = service.getShares(true, context)
@@ -291,7 +291,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
             )
 
         withContext(Dispatchers.IO) {
-            val service = MusicServiceFactory.getMusicService(context)
+            val service = MusicServiceFactory.getMusicService()
             val musicDirectory: MusicDirectory
             val musicFolderId = if (showSelectFolderHeader) {
                 activeServerProvider.getActiveServer().musicFolderId

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
@@ -75,7 +75,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
             } else {
                 val musicDirectory = service.getMusicDirectory(id, name, refresh, context)
 
-                if (Util.getShouldShowAllSongsByArtist(context) &&
+                if (Util.getShouldShowAllSongsByArtist() &&
                     musicDirectory.findChild(allSongsId) == null &&
                     hasOnlyFolders(musicDirectory)
                 ) {
@@ -133,7 +133,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
             val musicDirectory = service.getArtist(id, name, refresh, context)
 
-            if (Util.getShouldShowAllSongsByArtist(context) &&
+            if (Util.getShouldShowAllSongsByArtist() &&
                 musicDirectory.findChild(allSongsId) == null &&
                 hasOnlyFolders(musicDirectory)
             ) {
@@ -213,7 +213,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
             val musicDirectory: MusicDirectory
             val context = context
 
-            if (Util.getShouldUseId3Tags(context)) {
+            if (Util.getShouldUseId3Tags()) {
                 musicDirectory = Util.getSongsFromSearchResult(service.getStarred2(context))
             } else {
                 musicDirectory = Util.getSongsFromSearchResult(service.getStarred(context))
@@ -286,7 +286,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
         showHeader = false
         showSelectFolderHeader = !ActiveServerProvider.isOffline(context) &&
-            !Util.getShouldUseId3Tags(context) && (
+            !Util.getShouldUseId3Tags() && (
             (albumListType == AlbumListType.SORTED_BY_NAME.toString()) ||
                 (albumListType == AlbumListType.SORTED_BY_ARTIST.toString())
             )
@@ -300,7 +300,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
                 null
             }
 
-            if (Util.getShouldUseId3Tags(context)) {
+            if (Util.getShouldUseId3Tags()) {
                 musicDirectory = service.getAlbumList2(
                     albumListType, size,
                     offset, musicFolderId, context

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectAlbumModel.kt
@@ -40,7 +40,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
 
     suspend fun getMusicFolders(refresh: Boolean) {
         withContext(Dispatchers.IO) {
-            if (!ActiveServerProvider.isOffline(context)) {
+            if (!ActiveServerProvider.isOffline()) {
                 val musicService = MusicServiceFactory.getMusicService(context)
                 musicFolders.postValue(musicService.getMusicFolders(refresh))
             }
@@ -284,7 +284,7 @@ class SelectAlbumModel(application: Application) : AndroidViewModel(application)
     suspend fun getAlbumList(albumListType: String, size: Int, offset: Int) {
 
         showHeader = false
-        showSelectFolderHeader = !ActiveServerProvider.isOffline(context) &&
+        showSelectFolderHeader = !ActiveServerProvider.isOffline() &&
             !Util.getShouldUseId3Tags() && (
             (albumListType == AlbumListType.SORTED_BY_NAME.toString()) ||
                 (albumListType == AlbumListType.SORTED_BY_ARTIST.toString())

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectArtistFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectArtistFragment.kt
@@ -60,7 +60,7 @@ class SelectArtistFragment : Fragment() {
         }
 
         if (!ActiveServerProvider.isOffline(this.context) &&
-            !Util.getShouldUseId3Tags(this.context)
+            !Util.getShouldUseId3Tags()
         ) {
             selectFolderHeader = SelectMusicFolderView(
                 requireContext(), view as ViewGroup,

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectArtistFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SelectArtistFragment.kt
@@ -59,13 +59,13 @@ class SelectArtistFragment : Fragment() {
             artistListModel.refresh(refreshArtistListView!!)
         }
 
-        if (!ActiveServerProvider.isOffline(this.context) &&
+        if (!ActiveServerProvider.isOffline() &&
             !Util.getShouldUseId3Tags()
         ) {
             selectFolderHeader = SelectMusicFolderView(
                 requireContext(), view as ViewGroup,
                 { selectedFolderId ->
-                    if (!ActiveServerProvider.isOffline(context)) {
+                    if (!ActiveServerProvider.isOffline()) {
                         val currentSetting = activeServerProvider.getActiveServer()
                         currentSetting.musicFolderId = selectedFolderId
                         serverSettingsModel.updateItem(currentSetting)
@@ -81,7 +81,7 @@ class SelectArtistFragment : Fragment() {
         if (title == null) {
             setTitle(
                 this,
-                if (ActiveServerProvider.isOffline(this.context))
+                if (ActiveServerProvider.isOffline())
                     R.string.music_library_label_offline
                 else R.string.music_library_label
             )

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/log/FileLoggerTree.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/log/FileLoggerTree.kt
@@ -1,6 +1,5 @@
 package org.moire.ultrasonic.log
 
-import android.content.Context
 import java.io.File
 import java.io.FileWriter
 import java.text.SimpleDateFormat
@@ -14,7 +13,7 @@ import timber.log.Timber
  * A Timber Tree which can be used to log to a file
  * Subclass of the DebugTree so it inherits the Tag handling
  */
-class FileLoggerTree(val context: Context) : Timber.DebugTree() {
+class FileLoggerTree : Timber.DebugTree() {
     private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
 
     /**
@@ -81,7 +80,7 @@ class FileLoggerTree(val context: Context) : Timber.DebugTree() {
      */
     private fun getNumberedFile(next: Boolean) {
         var fileNum = 1
-        val fileList = getLogFileList(context)
+        val fileList = getLogFileList()
 
         if (!fileList.isNullOrEmpty()) {
             fileList.sortByDescending { t -> t.name }
@@ -94,7 +93,7 @@ class FileLoggerTree(val context: Context) : Timber.DebugTree() {
 
         if (next) fileNum++
         file = File(
-            FileUtil.getUltrasonicDirectory(context),
+            FileUtil.getUltrasonicDirectory(),
             FILENAME.replace("*", fileNum.toString())
         )
     }
@@ -124,9 +123,9 @@ class FileLoggerTree(val context: Context) : Timber.DebugTree() {
         const val MAX_LOGFILE_LENGTH = 10000000
         var callNum = 0
 
-        fun plantToTimberForest(context: Context) {
+        fun plantToTimberForest() {
             if (!Timber.forest().any { t -> t is FileLoggerTree }) {
-                Timber.plant(FileLoggerTree(context))
+                Timber.plant(FileLoggerTree())
             }
         }
 
@@ -137,15 +136,15 @@ class FileLoggerTree(val context: Context) : Timber.DebugTree() {
             file = null
         }
 
-        fun getLogFileNumber(context: Context): Int {
-            val fileList = getLogFileList(context)
+        fun getLogFileNumber(): Int {
+            val fileList = getLogFileList()
             if (!fileList.isNullOrEmpty()) return fileList.size
             return 0
         }
 
-        fun getLogFileSizes(context: Context): Long {
+        fun getLogFileSizes(): Long {
             var sizeSum: Long = 0
-            val fileList = getLogFileList(context)
+            val fileList = getLogFileList()
             if (fileList.isNullOrEmpty()) return sizeSum
             for (file in fileList) {
                 sizeSum += file.length()
@@ -153,16 +152,16 @@ class FileLoggerTree(val context: Context) : Timber.DebugTree() {
             return sizeSum
         }
 
-        fun deleteLogFiles(context: Context) {
-            val fileList = getLogFileList(context)
+        fun deleteLogFiles() {
+            val fileList = getLogFileList()
             if (fileList.isNullOrEmpty()) return
             for (file in fileList) {
                 file.delete()
             }
         }
 
-        private fun getLogFileList(context: Context): Array<File> {
-            val directory = FileUtil.getUltrasonicDirectory(context)
+        private fun getLogFileList(): Array<File> {
+            val directory = FileUtil.getUltrasonicDirectory()
             return directory.listFiles { t -> t.name.matches(fileNameRegex) }
         }
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/AudioFocusHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/AudioFocusHandler.kt
@@ -25,7 +25,7 @@ class AudioFocusHandler(private val context: Context) {
     }
 
     private val preferences by lazy {
-        Util.getPreferences(context)
+        Util.getPreferences()
     }
 
     private val lossPref: Int

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
@@ -41,7 +41,7 @@ class DownloadFile(
 ) {
     val partialFile: File
     val completeFile: File
-    private val saveFile: File = FileUtil.getSongFile(context, song)
+    private val saveFile: File = FileUtil.getSongFile(song)
     private var downloadTask: CancellableTask? = null
     var isFailed = false
     private var retryCount = MAX_RETRIES

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
@@ -312,7 +312,7 @@ class DownloadFile(
 
         private fun acquireWakeLock(wakeLock: WakeLock?): WakeLock? {
             var wakeLock1 = wakeLock
-            if (Util.isScreenLitOnDownload(context)) {
+            if (Util.isScreenLitOnDownload()) {
                 val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
                 val flags = PowerManager.SCREEN_DIM_WAKE_LOCK or PowerManager.ON_AFTER_RELEASE
                 wakeLock1 = pm.newWakeLock(flags, toString())

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/DownloadFile.kt
@@ -228,7 +228,7 @@ class DownloadFile(
                     return
                 }
 
-                val musicService = getMusicService(context)
+                val musicService = getMusicService()
 
                 // Some devices seem to throw error on partial file which doesn't exist
                 val needsDownloading: Boolean

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
@@ -601,7 +601,7 @@ class LocalMediaPlayer(
 
         override fun execute() {
             setPlayerState(PlayerState.DOWNLOADING)
-            while (!bufferComplete() && !isOffline(context)) {
+            while (!bufferComplete() && !isOffline()) {
                 Util.sleepQuietly(1000L)
                 if (isCancelled) {
                     return

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
@@ -472,7 +472,7 @@ class LocalMediaPlayer(
             nextMediaPlayer!!.setOnPreparedListener {
                 try {
                     setNextPlayerState(PlayerState.PREPARED)
-                    if (Util.getGaplessPlaybackPreference(context) &&
+                    if (Util.getGaplessPlaybackPreference() &&
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN &&
                         (
                             playerState === PlayerState.STARTED ||
@@ -526,7 +526,7 @@ class LocalMediaPlayer(
                 Timber.i("Ending position %d of %d", pos, duration)
                 if (!isPartial || downloadFile.isWorkDone && abs(duration - pos) < 1000) {
                     setPlayerState(PlayerState.COMPLETED)
-                    if (Util.getGaplessPlaybackPreference(context) &&
+                    if (Util.getGaplessPlaybackPreference() &&
                         nextPlaying != null &&
                         nextPlayerState === PlayerState.PREPARED
                     ) {
@@ -628,7 +628,7 @@ class LocalMediaPlayer(
         }
 
         init {
-            var bufferLength = Util.getBufferLength(context).toLong()
+            var bufferLength = Util.getBufferLength().toLong()
             if (bufferLength == 0L) {
                 // Set to seconds in a day, basically infinity
                 bufferLength = 86400L

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
@@ -65,7 +65,7 @@ class MediaPlayerService : Service() {
     private var notificationBuilder: NotificationCompat.Builder? = null
 
     private val repeatMode: RepeatMode
-        get() = Util.getRepeatMode(this)
+        get() = Util.getRepeatMode()
 
     override fun onBind(intent: Intent): IBinder {
         return binder
@@ -176,7 +176,7 @@ class MediaPlayerService : Service() {
 
     @Synchronized
     fun setNextPlaying() {
-        val gaplessPlayback = Util.getGaplessPlaybackPreference(this)
+        val gaplessPlayback = Util.getGaplessPlaybackPreference()
 
         if (!gaplessPlayback) {
             localMediaPlayer.clearNextPlaying(true)
@@ -376,7 +376,7 @@ class MediaPlayerService : Service() {
             }
 
             val showWhenPaused = playerState !== PlayerState.STOPPED &&
-                Util.isNotificationAlwaysEnabled(context)
+                Util.isNotificationAlwaysEnabled()
 
             val show = playerState === PlayerState.STARTED || showWhenPaused
             val song = currentPlaying?.song
@@ -421,7 +421,7 @@ class MediaPlayerService : Service() {
 
             if (currentPlaying != null) {
                 val song = currentPlaying.song
-                if (song.bookmarkPosition > 0 && Util.getShouldClearBookmark(context)) {
+                if (song.bookmarkPosition > 0 && Util.getShouldClearBookmark()) {
                     val musicService = getMusicService(context)
                     try {
                         musicService.deleteBookmark(song.id, context)
@@ -433,7 +433,7 @@ class MediaPlayerService : Service() {
                 when (repeatMode) {
                     RepeatMode.OFF -> {
                         if (index + 1 < 0 || index + 1 >= downloader.downloadList.size) {
-                            if (Util.getShouldClearPlaylist(context)) {
+                            if (Util.getShouldClearPlaylist()) {
                                 clear(true)
                                 jukeboxMediaPlayer.updatePlaylist()
                             }
@@ -576,7 +576,7 @@ class MediaPlayerService : Service() {
     fun updateNotification(playerState: PlayerState, currentPlaying: DownloadFile?) {
         val notification = buildForegroundNotification(playerState, currentPlaying)
 
-        if (Util.isNotificationEnabled(this)) {
+        if (Util.isNotificationEnabled()) {
             if (isInForeground) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
@@ -868,7 +868,7 @@ class MediaPlayerService : Service() {
     }
 
     fun updateMediaButtonReceiver() {
-        if (Util.getMediaButtonsEnabled(applicationContext)) {
+        if (Util.getMediaButtonsEnabled()) {
             registerMediaButtonEventReceiver()
         } else {
             unregisterMediaButtonEventReceiver()

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerService.kt
@@ -422,7 +422,7 @@ class MediaPlayerService : Service() {
             if (currentPlaying != null) {
                 val song = currentPlaying.song
                 if (song.bookmarkPosition > 0 && Util.getShouldClearBookmark()) {
-                    val musicService = getMusicService(context)
+                    val musicService = getMusicService()
                     try {
                         musicService.deleteBookmark(song.id, context)
                     } catch (ignored: Exception) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MusicServiceFactory.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MusicServiceFactory.kt
@@ -18,7 +18,7 @@
  */
 package org.moire.ultrasonic.service
 
-import android.content.Context
+import org.koin.core.component.KoinApiExtension
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.context.loadKoinModules
@@ -30,9 +30,10 @@ import org.moire.ultrasonic.di.ONLINE_MUSIC_SERVICE
 import org.moire.ultrasonic.di.musicServiceModule
 
 // TODO Refactor everywhere to use DI way to get MusicService, and then remove this class
+@KoinApiExtension
 object MusicServiceFactory : KoinComponent {
     @JvmStatic
-    fun getMusicService(context: Context): MusicService {
+    fun getMusicService(): MusicService {
         return if (ActiveServerProvider.isOffline()) {
             get(named(OFFLINE_MUSIC_SERVICE))
         } else {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MusicServiceFactory.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MusicServiceFactory.kt
@@ -33,7 +33,7 @@ import org.moire.ultrasonic.di.musicServiceModule
 object MusicServiceFactory : KoinComponent {
     @JvmStatic
     fun getMusicService(context: Context): MusicService {
-        return if (ActiveServerProvider.isOffline(context)) {
+        return if (ActiveServerProvider.isOffline()) {
             get(named(OFFLINE_MUSIC_SERVICE))
         } else {
             get(named(ONLINE_MUSIC_SERVICE))

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -219,7 +219,7 @@ open class RESTMusicService(
         return try {
             if (
                 !isOffline(context) &&
-                Util.getShouldUseId3Tags(context)
+                Util.getShouldUseId3Tags()
             ) search3(criteria)
             else search2(criteria)
         } catch (ignored: ApiNotSupportedException) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -108,10 +108,9 @@ open class RESTMusicService(
 
     @Throws(Exception::class)
     override fun getIndexes(
-        musicFolderId: String?,
-        refresh: Boolean,
-        context: Context
-    ): Indexes {
+        musicFolderId: String,
+        refresh: Boolean
+    ): Indexes? {
         val indexName = INDEXES_STORAGE_NAME + (musicFolderId ?: "")
 
         val cachedIndexes = fileStorage.load(indexName, getIndexesSerializer())
@@ -171,10 +170,9 @@ open class RESTMusicService(
     @Throws(Exception::class)
     override fun getMusicDirectory(
         id: String,
-        name: String?,
-        refresh: Boolean,
-        context: Context
-    ): MusicDirectory {
+        name: String,
+        refresh: Boolean
+    ): MusicDirectory? {
         val response = responseChecker.callWithResponseCheck { api ->
             api.getMusicDirectory(id).execute()
         }
@@ -280,7 +278,7 @@ open class RESTMusicService(
         }
 
         val playlist = response.body()!!.playlist.toMusicDirectoryDomainEntity()
-        savePlaylist(name, context, playlist)
+        savePlaylist(name, playlist)
 
         return playlist
     }
@@ -288,11 +286,10 @@ open class RESTMusicService(
     @Throws(IOException::class)
     private fun savePlaylist(
         name: String?,
-        context: Context,
         playlist: MusicDirectory
     ) {
         val playlistFile = FileUtil.getPlaylistFile(
-            context, activeServerProvider.getActiveServer().name, name
+            activeServerProvider.getActiveServer().name, name
         )
 
         val fw = FileWriter(playlistFile)
@@ -301,7 +298,7 @@ open class RESTMusicService(
         try {
             fw.write("#EXTM3U\n")
             for (e in playlist.getChildren()) {
-                var filePath = FileUtil.getSongFile(context, e).absolutePath
+                var filePath = FileUtil.getSongFile(e).absolutePath
 
                 if (!File(filePath).exists()) {
                     val ext = FileUtil.getExtension(filePath)
@@ -563,7 +560,7 @@ open class RESTMusicService(
                         var outputStream: OutputStream? = null
                         try {
                             outputStream = FileOutputStream(
-                                FileUtil.getAlbumArtFile(context, entry)
+                                FileUtil.getAlbumArtFile(entry)
                             )
                             outputStream.write(bytes)
                         } finally {
@@ -882,7 +879,7 @@ open class RESTMusicService(
 
         synchronized(username) {
             // Use cached file, if existing.
-            var bitmap = FileUtil.getAvatarBitmap(context, username, size, highQuality)
+            var bitmap = FileUtil.getAvatarBitmap(username, size, highQuality)
 
             if (bitmap == null) {
                 var inputStream: InputStream? = null
@@ -901,7 +898,7 @@ open class RESTMusicService(
 
                         try {
                             outputStream = FileOutputStream(
-                                FileUtil.getAvatarFile(context, username)
+                                FileUtil.getAvatarFile(username)
                             )
                             outputStream.write(bytes)
                         } finally {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -75,12 +75,12 @@ open class RESTMusicService(
 ) : MusicService {
 
     @Throws(Exception::class)
-    override fun ping(context: Context) {
+    override fun ping() {
         responseChecker.callWithResponseCheck { api -> api.ping().execute() }
     }
 
     @Throws(Exception::class)
-    override fun isLicenseValid(context: Context): Boolean {
+    override fun isLicenseValid(): Boolean {
         val response = responseChecker.callWithResponseCheck { api -> api.getLicense().execute() }
 
         return response.body()!!.license.valid
@@ -88,8 +88,7 @@ open class RESTMusicService(
 
     @Throws(Exception::class)
     override fun getMusicFolders(
-        refresh: Boolean,
-        context: Context
+        refresh: Boolean
     ): List<MusicFolder> {
         val cachedMusicFolders = fileStorage.load(
             MUSIC_FOLDER_STORAGE_NAME, getMusicFolderListSerializer()
@@ -129,8 +128,7 @@ open class RESTMusicService(
 
     @Throws(Exception::class)
     override fun getArtists(
-        refresh: Boolean,
-        context: Context
+        refresh: Boolean
     ): Indexes {
         val cachedArtists = fileStorage.load(ARTISTS_STORAGE_NAME, getIndexesSerializer())
         if (cachedArtists != null && !refresh) return cachedArtists
@@ -148,8 +146,7 @@ open class RESTMusicService(
     override fun star(
         id: String?,
         albumId: String?,
-        artistId: String?,
-        context: Context
+        artistId: String?
     ) {
         responseChecker.callWithResponseCheck { api -> api.star(id, albumId, artistId).execute() }
     }
@@ -158,8 +155,7 @@ open class RESTMusicService(
     override fun unstar(
         id: String?,
         albumId: String?,
-        artistId: String?,
-        context: Context
+        artistId: String?
     ) {
         responseChecker.callWithResponseCheck { api -> api.unstar(id, albumId, artistId).execute() }
     }
@@ -167,8 +163,7 @@ open class RESTMusicService(
     @Throws(Exception::class)
     override fun setRating(
         id: String,
-        rating: Int,
-        context: Context
+        rating: Int
     ) {
         responseChecker.callWithResponseCheck { api -> api.setRating(id, rating).execute() }
     }
@@ -191,8 +186,7 @@ open class RESTMusicService(
     override fun getArtist(
         id: String,
         name: String?,
-        refresh: Boolean,
-        context: Context
+        refresh: Boolean
     ): MusicDirectory {
         val response = responseChecker.callWithResponseCheck { api -> api.getArtist(id).execute() }
 
@@ -203,8 +197,7 @@ open class RESTMusicService(
     override fun getAlbum(
         id: String,
         name: String?,
-        refresh: Boolean,
-        context: Context
+        refresh: Boolean
     ): MusicDirectory {
         val response = responseChecker.callWithResponseCheck { api -> api.getAlbum(id).execute() }
 
@@ -446,8 +439,7 @@ open class RESTMusicService(
         type: String,
         size: Int,
         offset: Int,
-        musicFolderId: String?,
-        context: Context
+        musicFolderId: String?
     ): MusicDirectory {
         val response = responseChecker.callWithResponseCheck { api ->
             api.getAlbumList(fromName(type), size, offset, null, null, null, musicFolderId)
@@ -466,8 +458,7 @@ open class RESTMusicService(
         type: String,
         size: Int,
         offset: Int,
-        musicFolderId: String?,
-        context: Context
+        musicFolderId: String?
     ): MusicDirectory {
         val response = responseChecker.callWithResponseCheck { api ->
             api.getAlbumList2(
@@ -509,9 +500,7 @@ open class RESTMusicService(
     }
 
     @Throws(Exception::class)
-    override fun getStarred(
-        context: Context
-    ): SearchResult {
+    override fun getStarred(): SearchResult {
         val response = responseChecker.callWithResponseCheck { api ->
             api.getStarred(null).execute()
         }
@@ -520,9 +509,7 @@ open class RESTMusicService(
     }
 
     @Throws(Exception::class)
-    override fun getStarred2(
-        context: Context
-    ): SearchResult {
+    override fun getStarred2(): SearchResult {
         val response = responseChecker.callWithResponseCheck { api ->
             api.getStarred2(null).execute()
         }
@@ -743,8 +730,7 @@ open class RESTMusicService(
 
     @Throws(Exception::class)
     override fun getGenres(
-        refresh: Boolean,
-        context: Context
+        refresh: Boolean
     ): List<Genre> {
         val response = responseChecker.callWithResponseCheck { api -> api.getGenres().execute() }
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -211,7 +211,7 @@ open class RESTMusicService(
     ): SearchResult {
         return try {
             if (
-                !isOffline(context) &&
+                !isOffline() &&
                 Util.getShouldUseId3Tags()
             ) search3(criteria)
             else search2(criteria)
@@ -534,7 +534,7 @@ open class RESTMusicService(
         synchronized(entry) {
             // Use cached file, if existing.
             var bitmap = FileUtil.getAlbumArtBitmap(context, entry, size, highQuality)
-            val serverScaling = isServerScalingEnabled(context)
+            val serverScaling = isServerScalingEnabled()
 
             if (bitmap == null) {
                 Timber.d("Loading cover art for: %s", entry)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -108,7 +108,7 @@ open class RESTMusicService(
 
     @Throws(Exception::class)
     override fun getIndexes(
-        musicFolderId: String,
+        musicFolderId: String?,
         refresh: Boolean
     ): Indexes? {
         val indexName = INDEXES_STORAGE_NAME + (musicFolderId ?: "")
@@ -170,7 +170,7 @@ open class RESTMusicService(
     @Throws(Exception::class)
     override fun getMusicDirectory(
         id: String,
-        name: String,
+        name: String?,
         refresh: Boolean
     ): MusicDirectory? {
         val response = responseChecker.callWithResponseCheck { api ->

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
@@ -3,9 +3,9 @@ package org.moire.ultrasonic.subsonic
 import android.app.Activity
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import org.koin.core.component.KoinApiExtension
 import java.util.Collections
 import java.util.LinkedList
+import org.koin.core.component.KoinApiExtension
 import org.moire.ultrasonic.R
 import org.moire.ultrasonic.data.ActiveServerProvider.Companion.isOffline
 import org.moire.ultrasonic.domain.MusicDirectory
@@ -212,7 +212,7 @@ class DownloadHandler(
                         root = if (!isOffline() && Util.getShouldUseId3Tags())
                             musicService.getAlbum(id, name, false)
                         else
-                            musicService.getMusicDirectory(id, name, false, activity)
+                            musicService.getMusicDirectory(id, name, false)
                     } else if (isShare) {
                         root = MusicDirectory()
                         val shares = musicService.getShares(true, activity)
@@ -256,7 +256,7 @@ class DownloadHandler(
                         !isOffline() &&
                         Util.getShouldUseId3Tags()
                     ) musicService.getAlbum(id1, title, false)
-                    else musicService.getMusicDirectory(id1, title, false, activity)
+                    else musicService.getMusicDirectory(id1, title, false)
                     getSongsRecursively(root, songs)
                 }
             }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
@@ -208,7 +208,7 @@ class DownloadHandler(
                 } else {
                     if (isDirectory) {
                         root = if (!isOffline(activity) && Util.getShouldUseId3Tags())
-                            musicService.getAlbum(id, name, false, activity)
+                            musicService.getAlbum(id, name, false)
                         else
                             musicService.getMusicDirectory(id, name, false, activity)
                     } else if (isShare) {
@@ -253,7 +253,7 @@ class DownloadHandler(
                     val root: MusicDirectory = if (
                         !isOffline(activity) &&
                         Util.getShouldUseId3Tags()
-                    ) musicService.getAlbum(id1, title, false, activity)
+                    ) musicService.getAlbum(id1, title, false)
                     else musicService.getMusicDirectory(id1, title, false, activity)
                     getSongsRecursively(root, songs)
                 }
@@ -268,13 +268,12 @@ class DownloadHandler(
                     return
                 }
                 val musicService = getMusicService(activity)
-                val artist = musicService.getArtist(id, "", false, activity)
+                val artist = musicService.getArtist(id, "", false)
                 for ((id1) in artist.getChildren()) {
                     val albumDirectory = musicService.getAlbum(
                         id1,
                         "",
-                        false,
-                        activity
+                        false
                     )
                     for (song in albumDirectory.getChildren()) {
                         if (!song.isVideo) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
@@ -53,7 +53,7 @@ class DownloadHandler(
                 mediaPlayerController.suggestedPlaylistName = playlistName
             }
             if (autoPlay) {
-                if (Util.getShouldTransitionOnPlaybackPreference(fragment.activity)) {
+                if (Util.getShouldTransitionOnPlaybackPreference()) {
                     fragment.findNavController().popBackStack(R.id.playerFragment, true)
                     fragment.findNavController().navigate(R.id.playerFragment)
                 }
@@ -203,11 +203,11 @@ class DownloadHandler(
                 val musicService = getMusicService(activity)
                 val songs: MutableList<MusicDirectory.Entry> = LinkedList()
                 val root: MusicDirectory
-                if (!isOffline(activity) && isArtist && Util.getShouldUseId3Tags(activity)) {
+                if (!isOffline(activity) && isArtist && Util.getShouldUseId3Tags()) {
                     getSongsForArtist(id, songs)
                 } else {
                     if (isDirectory) {
-                        root = if (!isOffline(activity) && Util.getShouldUseId3Tags(activity))
+                        root = if (!isOffline(activity) && Util.getShouldUseId3Tags())
                             musicService.getAlbum(id, name, false, activity)
                         else
                             musicService.getMusicDirectory(id, name, false, activity)
@@ -252,7 +252,7 @@ class DownloadHandler(
                 ) {
                     val root: MusicDirectory = if (
                         !isOffline(activity) &&
-                        Util.getShouldUseId3Tags(activity)
+                        Util.getShouldUseId3Tags()
                     ) musicService.getAlbum(id1, title, false, activity)
                     else musicService.getMusicDirectory(id1, title, false, activity)
                     getSongsRecursively(root, songs)
@@ -285,7 +285,7 @@ class DownloadHandler(
             }
 
             override fun done(songs: List<MusicDirectory.Entry>) {
-                if (Util.getShouldSortByDisc(activity)) {
+                if (Util.getShouldSortByDisc()) {
                     Collections.sort(songs, EntryByDiscAndTrackComparator())
                 }
                 if (songs.isNotEmpty()) {
@@ -307,7 +307,7 @@ class DownloadHandler(
                             )
                             if (
                                 !append &&
-                                Util.getShouldTransitionOnPlaybackPreference(activity)
+                                Util.getShouldTransitionOnPlaybackPreference()
                             ) {
                                 fragment.findNavController().popBackStack(
                                     R.id.playerFragment,

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
@@ -203,11 +203,11 @@ class DownloadHandler(
                 val musicService = getMusicService(activity)
                 val songs: MutableList<MusicDirectory.Entry> = LinkedList()
                 val root: MusicDirectory
-                if (!isOffline(activity) && isArtist && Util.getShouldUseId3Tags()) {
+                if (!isOffline() && isArtist && Util.getShouldUseId3Tags()) {
                     getSongsForArtist(id, songs)
                 } else {
                     if (isDirectory) {
-                        root = if (!isOffline(activity) && Util.getShouldUseId3Tags())
+                        root = if (!isOffline() && Util.getShouldUseId3Tags())
                             musicService.getAlbum(id, name, false)
                         else
                             musicService.getMusicDirectory(id, name, false, activity)
@@ -251,7 +251,7 @@ class DownloadHandler(
                     )
                 ) {
                     val root: MusicDirectory = if (
-                        !isOffline(activity) &&
+                        !isOffline() &&
                         Util.getShouldUseId3Tags()
                     ) musicService.getAlbum(id1, title, false)
                     else musicService.getMusicDirectory(id1, title, false, activity)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/DownloadHandler.kt
@@ -3,6 +3,7 @@ package org.moire.ultrasonic.subsonic
 import android.app.Activity
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import org.koin.core.component.KoinApiExtension
 import java.util.Collections
 import java.util.LinkedList
 import org.moire.ultrasonic.R
@@ -18,6 +19,7 @@ import org.moire.ultrasonic.util.Util
 /**
  * Retrieves a list of songs and adds them to the now playing list
  */
+@KoinApiExtension
 class DownloadHandler(
     val mediaPlayerController: MediaPlayerController,
     val networkAndStorageChecker: NetworkAndStorageChecker
@@ -200,7 +202,7 @@ class DownloadHandler(
 
             @Throws(Throwable::class)
             override fun doInBackground(): List<MusicDirectory.Entry> {
-                val musicService = getMusicService(activity)
+                val musicService = getMusicService()
                 val songs: MutableList<MusicDirectory.Entry> = LinkedList()
                 val root: MusicDirectory
                 if (!isOffline() && isArtist && Util.getShouldUseId3Tags()) {
@@ -243,7 +245,7 @@ class DownloadHandler(
                         songs.add(song)
                     }
                 }
-                val musicService = getMusicService(activity)
+                val musicService = getMusicService()
                 for (
                     (id1, _, _, title) in parent.getChildren(
                         includeDirs = true,
@@ -267,7 +269,7 @@ class DownloadHandler(
                 if (songs.size > maxSongs) {
                     return
                 }
-                val musicService = getMusicService(activity)
+                val musicService = getMusicService()
                 val artist = musicService.getArtist(id, "", false)
                 for ((id1) in artist.getChildren()) {
                     val albumDirectory = musicService.getAlbum(

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ImageLoaderProvider.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ImageLoaderProvider.kt
@@ -31,7 +31,7 @@ class ImageLoaderProvider(val context: Context) {
         if (imageLoader == null || !imageLoader!!.isRunning) {
             val legacyImageLoader = LegacyImageLoader(
                 context,
-                Util.getImageLoaderConcurrency(context)
+                Util.getImageLoaderConcurrency()
             )
             val isNewImageLoaderEnabled = get(FeatureStorage::class.java)
                 .isFeatureEnabled(Feature.NEW_IMAGE_DOWNLOADER)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/NetworkAndStorageChecker.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/NetworkAndStorageChecker.kt
@@ -12,7 +12,7 @@ class NetworkAndStorageChecker(val context: Context) {
     fun warnIfNetworkOrStorageUnavailable() {
         if (!Util.isExternalStoragePresent()) {
             Util.toast(context, R.string.select_album_no_sdcard)
-        } else if (!isOffline(context) && !Util.isNetworkConnected(context)) {
+        } else if (!isOffline() && !Util.isNetworkConnected(context)) {
             Util.toast(context, R.string.select_album_no_network)
         }
     }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ShareHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ShareHandler.kt
@@ -76,7 +76,7 @@ class ShareHandler(val context: Context) {
                         ids.add(id)
                     }
                 }
-                val musicService = getMusicService(context)
+                val musicService = getMusicService()
                 var timeInMillis: Long = 0
                 if (shareDetails.Expiration != 0L) {
                     timeInMillis = shareDetails.Expiration

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ShareHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ShareHandler.kt
@@ -40,13 +40,13 @@ class ShareHandler(val context: Context) {
         swipe: SwipeRefreshLayout?,
         cancellationToken: CancellationToken
     ) {
-        val askForDetails = Util.getShouldAskForShareDetails(context)
+        val askForDetails = Util.getShouldAskForShareDetails()
         val shareDetails = ShareDetails()
         shareDetails.Entries = entries
         if (askForDetails) {
             showDialog(fragment, shareDetails, swipe, cancellationToken)
         } else {
-            shareDetails.Description = Util.getDefaultShareDescription(context)
+            shareDetails.Description = Util.getDefaultShareDescription()
             shareDetails.Expiration = TimeSpan.getCurrentTime().add(
                 Util.getDefaultShareExpirationInMillis(context)
             ).totalMilliseconds
@@ -131,17 +131,16 @@ class ShareHandler(val context: Context) {
             }
             shareDetails.Description = shareDescription!!.text.toString()
             if (hideDialogCheckBox!!.isChecked) {
-                Util.setShouldAskForShareDetails(context, false)
+                Util.setShouldAskForShareDetails(false)
             }
             if (saveAsDefaultsCheckBox!!.isChecked) {
                 val timeSpanType: String = timeSpanPicker!!.timeSpanType
                 val timeSpanAmount: Int = timeSpanPicker!!.timeSpanAmount
                 Util.setDefaultShareExpiration(
-                    context,
                     if (!noExpirationCheckBox!!.isChecked && timeSpanAmount > 0)
                         String.format("%d:%s", timeSpanAmount, timeSpanType) else ""
                 )
-                Util.setDefaultShareDescription(context, shareDetails.Description)
+                Util.setDefaultShareDescription(shareDetails.Description)
             }
             share(fragment, shareDetails, swipe, cancellationToken)
         }
@@ -156,8 +155,8 @@ class ShareHandler(val context: Context) {
             b ->
             timeSpanPicker!!.isEnabled = !b
         }
-        val defaultDescription = Util.getDefaultShareDescription(context)
-        val timeSpan = Util.getDefaultShareExpiration(context)
+        val defaultDescription = Util.getDefaultShareDescription()
+        val timeSpan = Util.getDefaultShareExpiration()
         val split = pattern.split(timeSpan)
         if (split.size == 2) {
             val timeSpanAmount = split[0].toInt()

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/VideoPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/VideoPlayer.kt
@@ -14,7 +14,7 @@ class VideoPlayer() {
             Util.toast(context, R.string.select_album_no_network)
             return
         }
-        val player = Util.getVideoPlayerType(context)
+        val player = Util.getVideoPlayerType()
         try {
             player.playVideo(context, entry)
         } catch (e: Exception) {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/SubsonicUncaughtExceptionHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/SubsonicUncaughtExceptionHandler.kt
@@ -22,7 +22,7 @@ class SubsonicUncaughtExceptionHandler(
         var printWriter: PrintWriter? = null
 
         try {
-            file = File(FileUtil.getUltrasonicDirectory(context), filename)
+            file = File(FileUtil.getUltrasonicDirectory(), filename)
             printWriter = PrintWriter(file)
             val logMessage = String.format(
                 "Android API level: %s\nUltrasonic version name: %s\n" +

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
@@ -204,9 +204,9 @@ class SongView(context: Context) : UpdateView(context), Checkable {
                         val musicService = getMusicService(this@SongView.context)
                         try {
                             if (!isStarred) {
-                                musicService.star(id, null, null, this@SongView.context)
+                                musicService.star(id, null, null)
                             } else {
-                                musicService.unstar(id, null, null, this@SongView.context)
+                                musicService.unstar(id, null, null)
                             }
                         } catch (e: Exception) {
                             Timber.e(e)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
@@ -161,7 +161,7 @@ class SongView(context: Context) : UpdateView(context), Checkable {
         viewHolder?.check?.visibility = if (checkable && !song.isVideo) VISIBLE else GONE
         viewHolder?.drag?.visibility = if (draggable) VISIBLE else GONE
 
-        if (isOffline(this.context)) {
+        if (isOffline()) {
             viewHolder?.star?.visibility = GONE
             viewHolder?.rating?.visibility = GONE
         } else {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
@@ -201,7 +201,7 @@ class SongView(context: Context) : UpdateView(context), Checkable {
                         song.starred = false
                     }
                     Thread {
-                        val musicService = getMusicService(this@SongView.context)
+                        val musicService = getMusicService()
                         try {
                             if (!isStarred) {
                                 musicService.star(id, null, null)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/view/SongView.kt
@@ -112,13 +112,13 @@ class SongView(context: Context) : UpdateView(context), Checkable {
 
         fileFormat = if (
             TextUtils.isEmpty(transcodedSuffix) || transcodedSuffix == suffix ||
-            song.isVideo && Util.getVideoPlayerType(this.context) !== VideoPlayerType.FLASH
+            song.isVideo && Util.getVideoPlayerType() !== VideoPlayerType.FLASH
         ) suffix else String.format("%s > %s", suffix, transcodedSuffix)
 
         val artistName = song.artist
 
         if (artistName != null) {
-            if (Util.shouldDisplayBitrateWithArtist(this.context)) {
+            if (Util.shouldDisplayBitrateWithArtist()) {
                 artist.append(artistName).append(" (").append(
                     String.format(
                         this.context.getString(R.string.song_details_all),
@@ -132,7 +132,7 @@ class SongView(context: Context) : UpdateView(context), Checkable {
 
         val trackNumber = song.track ?: 0
 
-        if (Util.shouldShowTrackNumber(this.context) && trackNumber != 0) {
+        if (Util.shouldShowTrackNumber() && trackNumber != 0) {
             viewHolder?.track?.text = String.format("%02d.", trackNumber)
         } else {
             viewHolder?.track?.visibility = GONE
@@ -141,7 +141,7 @@ class SongView(context: Context) : UpdateView(context), Checkable {
         val title = StringBuilder(60)
         title.append(song.title)
 
-        if (song.isVideo && Util.shouldDisplayBitrateWithArtist(this.context)) {
+        if (song.isVideo && Util.shouldDisplayBitrateWithArtist()) {
             title.append(" (").append(
                 String.format(
                     this.context.getString(R.string.song_details_all),
@@ -358,7 +358,7 @@ class SongView(context: Context) : UpdateView(context), Checkable {
     }
 
     init {
-        val theme = Util.getTheme(context)
+        val theme = Util.getTheme()
         val themesMatch = theme == Companion.theme
         inflater = LayoutInflater.from(this.context)
 


### PR DESCRIPTION
Passing around, and especially storing references to context can lead to memory leaks.

Furthermore, I am working to implement the [Android X Paging Library](https://developer.android.com/topic/libraries/architecture/paging/v3-overview) to get endless scrolling in our album views. For this I need API calls which don't require context.