### PR TITLE
Better experience for new users

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/activity/NavigationActivity.kt
@@ -326,7 +326,7 @@ class NavigationActivity : AppCompatActivity() {
                 .setTitle(R.string.main_welcome_title)
                 .setMessage(R.string.main_welcome_text_demo)
                 .setNegativeButton(R.string.main_welcome_cancel) { dialog, _ ->
-                    // Got to the settings screen
+                    // Go to the settings screen
                     dialog.dismiss()
                     findNavController(R.id.nav_host_fragment).navigate(R.id.settingsFragment)
                 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/AppPermanentStorageModule.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/di/AppPermanentStorageModule.kt
@@ -12,6 +12,7 @@ import org.moire.ultrasonic.fragment.ServerSettingsModel
 import org.moire.ultrasonic.util.Util
 
 const val SP_NAME = "Default_SP"
+const val DB_FILENAME = "ultrasonic-database"
 
 /**
  * This Koin module contains registration of classes related to permanent storage
@@ -23,11 +24,10 @@ val appPermanentStorage = module {
         Room.databaseBuilder(
             androidContext(),
             AppDatabase::class.java,
-            "ultrasonic-database"
+            DB_FILENAME
         )
             .addMigrations(MIGRATION_1_2)
             .addMigrations(MIGRATION_2_3)
-            .fallbackToDestructiveMigrationOnDowngrade()
             .build()
     }
 

--- a/ultrasonic/src/main/res/values-cs/strings.xml
+++ b/ultrasonic/src/main/res/values-cs/strings.xml
@@ -101,7 +101,6 @@
     <string name="main.songs_starred">Označené hvězdičkou</string>
     <string name="main.songs_title">Skladby</string>
     <string name="main.videos">Videa</string>
-    <string name="main.welcome_text">Vítejte v aplikaci Ultrasonic! Aplikace není ještě nakonfigurována. Poté co nastavíte svůj osobní server (dostupný na <b>subsonic.org</b>), vyberte <i>Správa serverů</i> v <b>Nastavení</b> a připojte aplikaci.</string>
     <string name="main.welcome_title">Vítejte!</string>
     <string name="menu.about">O aplikaci</string>
     <string name="menu.common">Další</string>

--- a/ultrasonic/src/main/res/values-de/strings.xml
+++ b/ultrasonic/src/main/res/values-de/strings.xml
@@ -100,7 +100,6 @@
     <string name="main.songs_starred">Mit Stern</string>
     <string name="main.songs_title">Titel</string>
     <string name="main.videos">Filme</string>
-    <string name="main.welcome_text">Willkommen bei Ultrasonic! Die App ist zurzeit unkonfiguriert. Nachdem du deinen Server konfiguriert hast (siehe <b>subsonic.org</b>), bitte <i>Server hinzufügen</i> in den <b>Einstellungen</b> klicken um die Verbindun herzustellen.</string>
     <string name="main.welcome_title">Willkommen</string>
     <string name="menu.about">Über</string>
     <string name="menu.common">Allgemein</string>

--- a/ultrasonic/src/main/res/values-es/strings.xml
+++ b/ultrasonic/src/main/res/values-es/strings.xml
@@ -111,7 +111,6 @@
     <string name="main.songs_starred">Me gusta</string>
     <string name="main.songs_title">Canciones</string>
     <string name="main.videos">Vídeos</string>
-    <string name="main.welcome_text">Te damos la bienvenida a Ultrasonic! La aplicación no está configurada actualmente. Después de que hayas configurado tu servidor personal (disponible desde <b>subsonic.org</b>), por favor haz click en <i>Administrar servidores</i> en <b>Configuración</b> para conectarte con él.</string>
     <string name="main.welcome_title">¡Saludos!</string>
     <string name="menu.about">Acerca de</string>
     <string name="menu.common">Común</string>

--- a/ultrasonic/src/main/res/values-fr/strings.xml
+++ b/ultrasonic/src/main/res/values-fr/strings.xml
@@ -101,7 +101,6 @@
     <string name="main.songs_starred">Favoris</string>
     <string name="main.songs_title">Titres</string>
     <string name="main.videos">Vidéos</string>
-    <string name="main.welcome_text">Bienvenue dans Ultrasonic ! L\'application n\'est pas configurée. Après avoir configuré votre serveur personnel (disponible à partir de <b>subsonic.org</b>), veuillez accéder aux <b>Paramètres</b> et modifier la configuration pour vous y connecter.</string>
     <string name="main.welcome_title">Bienvenue !</string>
     <string name="menu.about">À propos</string>
     <string name="menu.common">Général</string>

--- a/ultrasonic/src/main/res/values-hu/strings.xml
+++ b/ultrasonic/src/main/res/values-hu/strings.xml
@@ -111,7 +111,6 @@
     <string name="main.songs_starred">Csillaggal megjelölt</string>
     <string name="main.songs_title">Dalok</string>
     <string name="main.videos">Videók</string>
-    <string name="main.welcome_text">Üdvözli az Ultrasonic! Az alkalmazás még nincs beállítva. Miután konfigurálta saját kiszolgálóját (elérhető: <b>subsonic.org</b>), húzza balról jobbra az oldalsávot, lépjen be a <b>Beállítások</b> menüpontba, és adja meg csatlakozási adatokat!</string>
     <string name="main.welcome_title">Üdvözlet!</string>
     <string name="menu.about">Névjegy</string>
     <string name="menu.common">Általános</string>

--- a/ultrasonic/src/main/res/values-nl/strings.xml
+++ b/ultrasonic/src/main/res/values-nl/strings.xml
@@ -111,7 +111,6 @@
     <string name="main.songs_starred">Favorieten</string>
     <string name="main.songs_title">Nummers</string>
     <string name="main.videos">Video\'s</string>
-    <string name="main.welcome_text">Welkom bij Ultrasonic! De app is nog niet ingesteld. Nadat je je persoonlijke server hebt opgezet (beschikbaar op <b>subsonic.org</b>), kun je naar de <b>Instellingen</b> gaan en drukken op <i>Server toevoegen</i>.</string>
     <string name="main.welcome_title">Welkom!</string>
     <string name="menu.about">Over</string>
     <string name="menu.common">Algemeen</string>

--- a/ultrasonic/src/main/res/values-pl/strings.xml
+++ b/ultrasonic/src/main/res/values-pl/strings.xml
@@ -100,7 +100,6 @@
     <string name="main.songs_starred">Ulubione</string>
     <string name="main.songs_title">Utwory</string>
     <string name="main.videos">Klipy wideo</string>
-    <string name="main.welcome_text">Witaj w Ultrasonic! Obecnie aplikacja nie jest skonfigurowana. Jeśli masz uruchomiony własny serwer (dostępny na <b>subsonic.org</b>), proszę wybrać <i>Dodaj serwer</i> w <b>Ustawieniach</b> aby się z nim połączyć.</string>
     <string name="main.welcome_title">Witaj!</string>
     <string name="menu.about">O aplikacji</string>
     <string name="menu.common">Wspólne</string>

--- a/ultrasonic/src/main/res/values-pt-rBR/strings.xml
+++ b/ultrasonic/src/main/res/values-pt-rBR/strings.xml
@@ -101,7 +101,6 @@
     <string name="main.songs_starred">Favoritas</string>
     <string name="main.songs_title">Músicas</string>
     <string name="main.videos">Vídeos</string>
-    <string name="main.welcome_text">Bem-vindo ao Ultrasonic! O aplicativo ainda não está configurado. Após configurar seu servidor pessoal (disponível em <b>subsonic.org</b>), clique em <i>Adicionar Servidor</i> em <b>Configurações</b> para a conexão.</string>
     <string name="main.welcome_title">Bem-vindo!</string>
     <string name="menu.about">Sobre</string>
     <string name="menu.common">Comum</string>

--- a/ultrasonic/src/main/res/values-pt/strings.xml
+++ b/ultrasonic/src/main/res/values-pt/strings.xml
@@ -100,7 +100,6 @@
     <string name="main.songs_starred">Favoritas</string>
     <string name="main.songs_title">Músicas</string>
     <string name="main.videos">Vídeos</string>
-    <string name="main.welcome_text">Bem-vindo ao Ultrasonic! O aplicativo ainda não está configurado. Após configurar seu servidor pessoal (disponível em <b>subsonic.org</b>), clique em <i>Adicionar Servidor</i> em <b>Configurações</b> para a conexão.</string>
     <string name="main.welcome_title">Bem-vindo!</string>
     <string name="menu.about">Sobre</string>
     <string name="menu.common">Comum</string>

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="background_task.loading">Loading&#8230;</string>
     <string name="background_task.network_error">A network error occurred. Please check the server address or try again later.</string>
@@ -111,8 +111,9 @@
     <string name="main.songs_starred">Starred</string>
     <string name="main.songs_title">Songs</string>
     <string name="main.videos">Videos</string>
-    <string name="main.welcome_text">Welcome to Ultrasonic! The app is currently not configured. After you\'ve set up your personal server (available from <b>subsonic.org</b>), please click <i>Manage Servers</i> in <b>Settings</b> to connect to it.</string>
-    <string name="main.welcome_title">Welcome!</string>
+    <string name="main.welcome_text_demo">To use Ultrasonic with your own music you will need your <b>own server</b>: \n\n➤ In case you want to try out the app first, it can add a demo server now. \n\n➤ Otherwise you can configure your server it in the <b>settings</b>.</string>
+    <string name="main.welcome_title">Welcome to Ultrasonic!</string>
+    <string name="main.welcome_cancel">Take me to the settings</string>
     <string name="menu.about">About</string>
     <string name="menu.common">Common</string>
     <string name="menu.deleted_playlist">Deleted playlist %s</string>
@@ -348,7 +349,7 @@
     <string name="util.bytes_format.gigabyte">0.00 GB</string>
     <string name="util.bytes_format.kilobyte">0 KB</string>
     <string name="util.bytes_format.megabyte">0.00 MB</string>
-    <string name="util.no_time">-:--</string>
+    <string name="util.no_time" tools:ignore="TypographyDashes">-:--</string>
     <string name="util.zero_time">0:00</string>
     <string name="video.get_mx_player_text">MX Player is not installed. Get it for free on Play Store, or change video settings.</string>
     <string name="video.get_mx_player_button">Get MX Player</string>
@@ -449,6 +450,7 @@
     <string name="server_editor.authentication">Authentication</string>
     <string name="server_editor.advanced">Advanced settings</string>
     <string name="server_editor.disabled_feature">One or more features were disabled because the server doesn\'t support them.\nYou can run this test again anytime.</string>
+    <string name="server_menu.demo">Demo Server</string>
 
     <plurals name="select_album_n_songs">
         <item quantity="one">1 song</item>

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -111,7 +111,7 @@
     <string name="main.songs_starred">Starred</string>
     <string name="main.songs_title">Songs</string>
     <string name="main.videos">Videos</string>
-    <string name="main.welcome_text_demo">To use Ultrasonic with your own music you will need your <b>own server</b>: \n\n➤ In case you want to try out the app first, it can add a demo server now. \n\n➤ Otherwise you can configure your server it in the <b>settings</b>.</string>
+    <string name="main.welcome_text_demo">To use Ultrasonic with your own music you will need your <b>own server</b>. \n\n➤ In case you want to try out the app first, it can add a demo server now. \n\n➤ Otherwise you can configure your server in the <b>settings</b>.</string>
     <string name="main.welcome_title">Welcome to Ultrasonic!</string>
     <string name="main.welcome_cancel">Take me to the settings</string>
     <string name="menu.about">About</string>

--- a/ultrasonic/src/main/res/xml/settings.xml
+++ b/ultrasonic/src/main/res/xml/settings.xml
@@ -70,13 +70,13 @@
         a:key="playbackControlSettings"
         app:iconSpaceReserved="false">
         <CheckBoxPreference
-            a:defaultValue="false"
+            a:defaultValue="true"
             a:key="useId3Tags"
             a:summary="@string/settings.use_id3_summary"
             a:title="@string/settings.use_id3"
             app:iconSpaceReserved="false"/>
         <CheckBoxPreference
-            a:defaultValue="false"
+            a:defaultValue="true"
             a:key="showArtistPicture"
             a:summary="@string/settings.show_artist_picture_summary"
             a:title="@string/settings.show_artist_picture"


### PR DESCRIPTION
With this PR our database is prepopulated with a demo server running ampache (see https://github.com/ampache/ampache/issues/2938 )

This makes it more welcoming for new users because they can check out the app before getting a server themselves.
Also sets the default preferences for new users to use ID3 display. This is what most people are used to from iTunes or Spotify.