### PR TITLE
Moved drag handle to the left in the Now Playing list

### DIFF
--- a/ultrasonic/src/main/res/drawable/ic_drag_vertical_dark.xml
+++ b/ultrasonic/src/main/res/drawable/ic_drag_vertical_dark.xml
@@ -1,0 +1,8 @@
+<!-- drawable/drag_vertical.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FFF" android:pathData="M9,3H11V5H9V3M13,3H15V5H13V3M9,7H11V9H9V7M13,7H15V9H13V7M9,11H11V13H9V11M13,11H15V13H13V11M9,15H11V17H9V15M13,15H15V17H13V15M9,19H11V21H9V19M13,19H15V21H13V19Z" />
+</vector>

--- a/ultrasonic/src/main/res/drawable/ic_drag_vertical_light.xml
+++ b/ultrasonic/src/main/res/drawable/ic_drag_vertical_light.xml
@@ -1,0 +1,8 @@
+<!-- drawable/drag_vertical.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M9,3H11V5H9V3M13,3H15V5H13V3M9,7H11V9H9V7M13,7H15V9H13V7M9,11H11V13H9V11M13,11H15V13H13V11M9,15H11V17H9V15M13,15H15V17H13V15M9,19H11V21H9V19M13,19H15V21H13V19Z" />
+</vector>

--- a/ultrasonic/src/main/res/layout/song_list_item.xml
+++ b/ultrasonic/src/main/res/layout/song_list_item.xml
@@ -4,7 +4,19 @@
     a:layout_width="fill_parent"
     a:layout_height="wrap_content"
     a:minHeight="?android:attr/listPreferredItemHeight"
-    a:orientation="horizontal" >
+    a:orientation="horizontal"
+    a:background="?attr/color_menu_background">
+
+    <ImageView
+        a:id="@+id/song_drag"
+        a:layout_width="wrap_content"
+        a:layout_height="fill_parent"
+        a:paddingLeft="5dip"
+        a:paddingStart="5dip"
+        a:background="@android:color/transparent"
+        a:focusable="false"
+        a:gravity="center_vertical"
+        a:src="?attr/drag_vertical" />
 
     <CheckedTextView
         a:id="@+id/song_check"
@@ -86,16 +98,5 @@
         a:gravity="center_vertical"
         a:paddingRight="8dip"
         a:src="?attr/star_hollow" />
-
-    <ImageView
-        a:id="@+id/song_drag"
-        a:layout_width="wrap_content"
-        a:layout_height="fill_parent"
-        a:background="@android:color/transparent"
-        a:focusable="false"
-        a:gravity="center_vertical"
-        a:layout_marginRight="16dip"
-        a:src="?attr/drag_queue"
-        a:layout_marginEnd="16dip" />
 
 </LinearLayout>

--- a/ultrasonic/src/main/res/layout/song_list_item.xml
+++ b/ultrasonic/src/main/res/layout/song_list_item.xml
@@ -13,6 +13,8 @@
         a:layout_height="fill_parent"
         a:paddingLeft="5dip"
         a:paddingStart="5dip"
+        a:paddingRight="0dip"
+        a:paddingEnd="0dip"
         a:background="@android:color/transparent"
         a:focusable="false"
         a:gravity="center_vertical"

--- a/ultrasonic/src/main/res/values/styles.xml
+++ b/ultrasonic/src/main/res/values/styles.xml
@@ -92,6 +92,7 @@
     <attr name="filepicker_subdirectory_up" format="reference"/>
     <attr name="filepicker_sd_card" format="reference"/>
     <attr name="drag_queue" format="reference"/>
+    <attr name="drag_vertical" format="reference"/>
     <attr name="more_vert" format="reference"/>
     <attr name="list_selector_holo" format="reference"/>
     <attr name="list_selector_holo_selected" format="reference"/>

--- a/ultrasonic/src/main/res/values/themes.xml
+++ b/ultrasonic/src/main/res/values/themes.xml
@@ -57,6 +57,7 @@
         <item name="filepicker_subdirectory_up">@drawable/ic_subdirectory_up_dark</item>
         <item name="filepicker_sd_card">@drawable/ic_sd_storage_dark</item>
         <item name="drag_queue">@drawable/ic_drag_queue_dark</item>
+        <item name="drag_vertical">@drawable/ic_drag_vertical_dark</item>
         <item name="more_vert">@drawable/ic_more_vert_dark</item>
         <item name="list_selector_holo">@drawable/list_selector_holo_dark</item>
         <item name="list_selector_holo_selected">@drawable/list_selector_holo_dark_selected</item>
@@ -119,6 +120,7 @@
         <item name="filepicker_subdirectory_up">@drawable/ic_subdirectory_up_dark</item>
         <item name="filepicker_sd_card">@drawable/ic_sd_storage_dark</item>
         <item name="drag_queue">@drawable/ic_drag_queue_dark</item>
+        <item name="drag_vertical">@drawable/ic_drag_vertical_dark</item>
         <item name="more_vert">@drawable/ic_more_vert_dark</item>
         <item name="list_selector_holo">@drawable/list_selector_holo_dark</item>
         <item name="list_selector_holo_selected">@drawable/list_selector_holo_dark_selected</item>
@@ -181,6 +183,7 @@
         <item name="filepicker_subdirectory_up">@drawable/ic_subdirectory_up_light</item>
         <item name="filepicker_sd_card">@drawable/ic_sd_storage_light</item>
         <item name="drag_queue">@drawable/ic_drag_queue_light</item>
+        <item name="drag_vertical">@drawable/ic_drag_vertical_light</item>
         <item name="more_vert">@drawable/ic_more_vert_light</item>
         <item name="list_selector_holo">@drawable/list_selector_holo_light</item>
         <item name="list_selector_holo_selected">@drawable/list_selector_holo_light_selected</item>


### PR DESCRIPTION
This fixes #569 

The scrollbar on the right side of the Now Playing list is wider than it seems, and it is very hard to drag a list item instead of starting to scroll inadvertently. Ultrasonic also displays lots of info in a list item, so it is hard to make the drag handle wide enough on the right side to solve this issue.

As a solution, the drag handle was moved to the left side, where it is easier to use it. 
I've also changed its icon to the tall dotted one, which looks a bit slimmer, and leaves more space to the list item details.

@tzugen @ogarcia could you guys please check if it looks / works OK for you?