### PR TITLE
Added link to the wiki for enabling Ultrasonic with Android Auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ App is available to download at following stores:
 
 **Warning**: All three versions (Google Play, F-Droid and the APKs) are not
 compatible (not signed by the same key)! You must uninstall one to install
-the other, which will delete all your data.
+the other, which will delete all your data.  
+
+If you want to use the version downloaded from F-Droid or form Github with **Android Auto**, you must enable Unknown Sources as it is described in [this wiki page](https://github.com/ultrasonic/ultrasonic/wiki/Using-Ultrasonic-with-Android-Auto).
 
 ## Bugs and issues
 


### PR DESCRIPTION
Also see ultrasonic#575
When Ultrasonic is not installed from the Play Store, it won't show up until Unknown Sources is enabled in the Android Auto Settings.
I've created a wiki page describing this problem and how to solve it, but I think it is a good idea to make this more visible including it in the readme.