### PR TITLE
Run dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+


### PR DESCRIPTION
Now that our dependencies are up-to-date,
run dependabot only once per month, and also ignore patch releases,
in order to avoid frequent PRs that all require a review by us.