### PR TITLE
Fixed album lists

### DIFF
--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/models/Album.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/models/Album.kt
@@ -5,14 +5,19 @@ import java.util.Calendar
 
 data class Album(
     val id: String = "",
+    val parent: String = "",
+    val album: String = "",
+    val title: String = "",
     val name: String = "",
+    val discNumber: Int = 0,
     val coverArt: String = "",
+    val songCount: Int = 0,
+    val created: Calendar? = null,
     val artist: String = "",
     val artistId: String = "",
-    val songCount: Int = 0,
     val duration: Int = 0,
-    val created: Calendar? = null,
     val year: Int = 0,
     val genre: String = "",
-    @JsonProperty("song") val songList: List<MusicDirectoryChild> = emptyList()
+    @JsonProperty("song") val songList: List<MusicDirectoryChild> = emptyList(),
+    @JsonProperty("starred") val starredDate: String = ""
 )

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/domain/APIAlbumConverter.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/domain/APIAlbumConverter.kt
@@ -16,7 +16,8 @@ fun Album.toDomainEntity(): MusicDirectory.Entry = MusicDirectory.Entry(
     duration = this@toDomainEntity.duration,
     created = this@toDomainEntity.created?.time,
     year = this@toDomainEntity.year,
-    genre = this@toDomainEntity.genre
+    genre = this@toDomainEntity.genre,
+    starred = this@toDomainEntity.starredDate.isNotEmpty()
 )
 
 fun Album.toMusicDirectoryDomainEntity(): MusicDirectory = MusicDirectory().apply {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/AlbumListFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/AlbumListFragment.kt
@@ -63,7 +63,8 @@ class AlbumListFragment : GenericListFragment<MusicDirectory.Entry, AlbumRowAdap
             { entry -> onItemClick(entry) },
             { menuItem, entry -> onContextMenuItemSelected(menuItem, entry) },
             imageLoaderProvider.getImageLoader(),
-            onMusicFolderUpdate
+            onMusicFolderUpdate,
+            requireContext()
         )
     }
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/AlbumRowAdapter.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/AlbumRowAdapter.kt
@@ -107,7 +107,6 @@ class AlbumRowAdapter(
     /**
      * Handles the star / unstar action for an album
      */
-    @Suppress("TooGenericExceptionCaught")
     private fun onStarClick(entry: MusicDirectory.Entry, star: ImageView) {
         entry.starred = !entry.starred
         star.setImageDrawable(if (entry.starred) starDrawable else starHollowDrawable)
@@ -128,8 +127,8 @@ class AlbumRowAdapter(
                         null
                     )
                 }
-            } catch (exception: Exception) {
-                Timber.e(exception)
+            } catch (all: Exception) {
+                Timber.e(all)
             }
         }.start()
     }

--- a/ultrasonic/src/main/res/layout/album_list_item.xml
+++ b/ultrasonic/src/main/res/layout/album_list_item.xml
@@ -36,14 +36,14 @@
         a:paddingLeft="3dip"
         a:paddingRight="3dip"
         a:textAppearance="?android:attr/textAppearanceMedium"
-        app:layout_constraintEnd_toStartOf="@+id/guideline2"
+        app:layout_constraintEnd_toStartOf="@+id/album_star"
         app:layout_constraintLeft_toRightOf="@+id/album_coverart"
         app:layout_constraintStart_toEndOf="@+id/album_coverart"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             a:id="@+id/album_title"
-            a:layout_width="wrap_content"
+            a:layout_width="match_parent"
             a:layout_height="wrap_content"
             a:ellipsize="marquee"
             a:singleLine="true"
@@ -52,7 +52,7 @@
 
         <TextView
             a:id="@+id/album_artist"
-            a:layout_width="wrap_content"
+            a:layout_width="match_parent"
             a:layout_height="wrap_content"
             a:singleLine="true"
             a:textAppearance="?android:attr/textAppearanceSmall"
@@ -67,29 +67,15 @@
         a:layout_marginStart="16dp"
         a:layout_marginLeft="16dp"
         a:layout_marginTop="16dp"
+        a:layout_marginEnd="20dp"
+        a:layout_marginRight="20dp"
         a:background="@android:color/transparent"
-        a:focusable="false"
         a:gravity="center_horizontal"
-        a:paddingRight="3dip"
         a:src="?attr/star_hollow"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toRightOf="@+id/row_album_details"
         app:layout_constraintStart_toEndOf="@+id/row_album_details"
         app:layout_constraintTop_toTopOf="parent"
-        tools:src="@drawable/ic_star_hollow_dark"
-        a:paddingEnd="3dip" />
-
-    <androidx.constraintlayout.widget.Guideline
-        a:id="@+id/guideline"
-        a:layout_width="wrap_content"
-        a:layout_height="wrap_content"
-        a:orientation="vertical"
-        app:layout_constraintGuide_begin="76dp" />
-
-    <androidx.constraintlayout.widget.Guideline
-        a:id="@+id/guideline2"
-        a:layout_width="wrap_content"
-        a:layout_height="wrap_content"
-        a:orientation="vertical"
-        app:layout_constraintGuide_begin="346dp" />
+        tools:src="@drawable/ic_star_hollow_dark" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixed a few issues with album lists:
- The controls didn't scale with landscape mode
- The starring of the albums didn't work
- It seems the starred state wasn't even read up from the Subsonic API correctly

Edit: ok I'm starting to get it... the "starred" property of an album on the original Subsonic API isn't documented, probably that's why it was omitted in Ultrasonic. However, every server supports it that I tried, and it is more user friendly to process it if present.