### PR TITLE
Added PlaybackComplete intent when a song playback is completed

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/LocalMediaPlayer.kt
@@ -536,6 +536,7 @@ class LocalMediaPlayer : KoinComponent {
                 wakeLock.acquire(60000)
                 val pos = cachedPosition
                 Timber.i("Ending position %d of %d", pos, duration)
+
                 if (!isPartial || downloadFile.isWorkDone && abs(duration - pos) < 1000) {
                     setPlayerState(PlayerState.COMPLETED)
                     if (Settings.gaplessPlayback &&
@@ -555,6 +556,7 @@ class LocalMediaPlayer : KoinComponent {
                     }
                     return
                 }
+
                 synchronized(this) {
                     if (downloadFile.isWorkDone) {
                         // Complete was called early even though file is fully buffered

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Util.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Util.kt
@@ -565,7 +565,11 @@ object Util {
     }
 
     private fun fillIntent(
-        intent: Intent, song: MusicDirectory.Entry?, playerPosition: Int, id: Int, listSize: Int
+        intent: Intent,
+        song: MusicDirectory.Entry?,
+        playerPosition: Int,
+        id: Int,
+        listSize: Int
     ) {
         if (song == null) {
             intent.putExtra("track", "")


### PR DESCRIPTION
Fixes #552 
There was a missing AVRCP intent that should be sent when the playback of a track completes. 
Ultrasonic sent a "stop" intent instead of this, which also caused some strange behavior for connected devices (like blinking stop state)