### PR TITLE
Added option whether to create a share on the server when sharing songs

### DIFF
--- a/ultrasonic/src/main/java/org/moire/ultrasonic/util/ShareDetails.java
+++ b/ultrasonic/src/main/java/org/moire/ultrasonic/util/ShareDetails.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class ShareDetails
 {
 	public String Description;
+	public boolean ShareOnServer;
 	public long Expiration;
 	public List<MusicDirectory.Entry> Entries;
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ShareHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/subsonic/ShareHandler.kt
@@ -7,6 +7,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.CheckBox
 import android.widget.EditText
+import android.widget.TextView
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import java.util.Locale
@@ -31,9 +33,12 @@ import org.moire.ultrasonic.util.TimeSpanPicker
 class ShareHandler(val context: Context) {
     private var shareDescription: EditText? = null
     private var timeSpanPicker: TimeSpanPicker? = null
+    private var shareOnServerCheckBox: CheckBox? = null
     private var hideDialogCheckBox: CheckBox? = null
     private var noExpirationCheckBox: CheckBox? = null
     private var saveAsDefaultsCheckBox: CheckBox? = null
+    private var textViewComment: TextView? = null
+    private var textViewExpiration: TextView? = null
     private val pattern = Pattern.compile(":")
 
     fun createShare(
@@ -62,15 +67,17 @@ class ShareHandler(val context: Context) {
         swipe: SwipeRefreshLayout?,
         cancellationToken: CancellationToken
     ) {
-        val task: BackgroundTask<Share> = object : FragmentBackgroundTask<Share>(
+        val task: BackgroundTask<Share?> = object : FragmentBackgroundTask<Share?>(
             fragment.requireActivity(),
             true,
             swipe,
             cancellationToken
         ) {
             @Throws(Throwable::class)
-            override fun doInBackground(): Share {
+            override fun doInBackground(): Share? {
                 val ids: MutableList<String> = ArrayList()
+
+                if (!shareDetails.ShareOnServer && shareDetails.Entries.size == 1) return null
                 if (shareDetails.Entries.isEmpty()) {
                     fragment.arguments?.getString(Constants.INTENT_EXTRA_NAME_ID)?.let {
                         ids.add(it)
@@ -80,23 +87,51 @@ class ShareHandler(val context: Context) {
                         ids.add(id)
                     }
                 }
+
                 val musicService = getMusicService()
                 var timeInMillis: Long = 0
+
                 if (shareDetails.Expiration != 0L) {
                     timeInMillis = shareDetails.Expiration
                 }
+
                 val shares =
                     musicService.createShare(ids, shareDetails.Description, timeInMillis)
+
                 return shares[0]
             }
 
-            override fun done(result: Share) {
+            override fun done(result: Share?) {
+
                 val intent = Intent(Intent.ACTION_SEND)
                 intent.type = "text/plain"
-                intent.putExtra(
-                    Intent.EXTRA_TEXT,
-                    String.format(Locale.ROOT, "%s\n\n%s", Settings.shareGreeting, result.url)
-                )
+
+                if (result != null) {
+                    // Created a share, send the URL
+                    intent.putExtra(
+                        Intent.EXTRA_TEXT,
+                        String.format(
+                            Locale.ROOT, "%s\n\n%s", Settings.shareGreeting, result.url
+                        )
+                    )
+                } else {
+                    // Sending only text details
+                    val textBuilder = StringBuilder()
+                    textBuilder.appendLine(Settings.shareGreeting)
+
+                    if (!shareDetails.Entries[0].title.isNullOrEmpty())
+                        textBuilder.append(context.resources.getString(R.string.common_title))
+                            .append(": ").appendLine(shareDetails.Entries[0].title)
+                    if (!shareDetails.Entries[0].artist.isNullOrEmpty())
+                        textBuilder.append(context.resources.getString(R.string.common_artist))
+                            .append(": ").appendLine(shareDetails.Entries[0].artist)
+                    if (!shareDetails.Entries[0].album.isNullOrEmpty())
+                        textBuilder.append(context.resources.getString(R.string.common_album))
+                            .append(": ").append(shareDetails.Entries[0].album)
+
+                    intent.putExtra(Intent.EXTRA_TEXT, textBuilder.toString())
+                }
+
                 fragment.activity?.startActivity(
                     Intent.createChooser(
                         intent,
@@ -119,24 +154,45 @@ class ShareHandler(val context: Context) {
         if (layout != null) {
             shareDescription = layout.findViewById<View>(R.id.share_description) as EditText
             hideDialogCheckBox = layout.findViewById<View>(R.id.hide_dialog) as CheckBox
+            shareOnServerCheckBox = layout.findViewById<View>(R.id.share_on_server) as CheckBox
             noExpirationCheckBox = layout.findViewById<View>(
                 R.id.timeSpanDisableCheckBox
             ) as CheckBox
             saveAsDefaultsCheckBox = layout.findViewById<View>(R.id.save_as_defaults) as CheckBox
             timeSpanPicker = layout.findViewById<View>(R.id.date_picker) as TimeSpanPicker
+            textViewComment = layout.findViewById<View>(R.id.textViewComment) as TextView
+            textViewExpiration = layout.findViewById<View>(R.id.textViewExpiration) as TextView
         }
+
+        if (shareDetails.Entries.size == 1) {
+            // For single songs the sharing may be done by text only
+            shareOnServerCheckBox?.setOnCheckedChangeListener { _, _ ->
+                updateVisibility()
+            }
+
+            shareOnServerCheckBox?.isChecked = Settings.shareOnServer
+        } else {
+            shareOnServerCheckBox?.isVisible = false
+        }
+        updateVisibility()
+
         val builder = AlertDialog.Builder(fragment.context)
         builder.setTitle(R.string.share_set_share_options)
-        builder.setPositiveButton(R.string.common_save) { _, _ ->
+
+        builder.setPositiveButton(R.string.menu_share) { _, _ ->
             if (!noExpirationCheckBox!!.isChecked) {
                 val timeSpan: TimeSpan = timeSpanPicker!!.timeSpan
                 val now = TimeSpan.getCurrentTime()
                 shareDetails.Expiration = now.add(timeSpan).totalMilliseconds
             }
+
             shareDetails.Description = shareDescription!!.text.toString()
+            shareDetails.ShareOnServer = shareOnServerCheckBox!!.isChecked
+
             if (hideDialogCheckBox!!.isChecked) {
                 Settings.shouldAskForShareDetails = false
             }
+
             if (saveAsDefaultsCheckBox!!.isChecked) {
                 val timeSpanType: String = timeSpanPicker!!.timeSpanType
                 val timeSpanAmount: Int = timeSpanPicker!!.timeSpanAmount
@@ -145,22 +201,29 @@ class ShareHandler(val context: Context) {
                         String.format("%d:%s", timeSpanAmount, timeSpanType) else ""
 
                 Settings.defaultShareDescription = shareDetails.Description
+                Settings.shareOnServer = shareDetails.ShareOnServer
             }
+
             share(fragment, shareDetails, swipe, cancellationToken)
         }
+
         builder.setNegativeButton(R.string.common_cancel) { dialog, _ ->
             dialog.cancel()
         }
+
         builder.setView(layout)
         builder.setCancelable(true)
+
         timeSpanPicker!!.setTimeSpanDisableText(context.resources.getString(R.string.no_expiration))
         noExpirationCheckBox!!.setOnCheckedChangeListener {
             _,
             b ->
             timeSpanPicker!!.isEnabled = !b
         }
+
         val defaultDescription = Settings.defaultShareDescription
         val timeSpan = Settings.defaultShareExpiration
+
         val split = pattern.split(timeSpan)
         if (split.size == 2) {
             val timeSpanAmount = split[0].toInt()
@@ -178,8 +241,25 @@ class ShareHandler(val context: Context) {
             noExpirationCheckBox!!.isChecked = true
             timeSpanPicker!!.isEnabled = false
         }
+
         shareDescription!!.setText(defaultDescription)
         builder.create()
         builder.show()
+    }
+
+    private fun updateVisibility() {
+        if (!shareOnServerCheckBox!!.isVisible || shareOnServerCheckBox!!.isChecked) {
+            noExpirationCheckBox?.isVisible = true
+            timeSpanPicker?.isVisible = true
+            shareDescription?.isVisible = true
+            textViewComment?.isVisible = true
+            textViewExpiration?.isVisible = true
+        } else {
+            noExpirationCheckBox?.isVisible = false
+            timeSpanPicker?.isVisible = false
+            shareDescription?.isVisible = false
+            textViewComment?.isVisible = false
+            textViewExpiration?.isVisible = false
+        }
     }
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Constants.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Constants.kt
@@ -105,6 +105,7 @@ object Constants {
     const val PREFERENCES_KEY_ASK_FOR_SHARE_DETAILS = "sharingAlwaysAskForDetails"
     const val PREFERENCES_KEY_DEFAULT_SHARE_DESCRIPTION = "sharingDefaultDescription"
     const val PREFERENCES_KEY_DEFAULT_SHARE_GREETING = "sharingDefaultGreeting"
+    const val PREFERENCES_KEY_SHARE_ON_SERVER = "sharingCreateOnServer"
     const val PREFERENCES_KEY_DEFAULT_SHARE_EXPIRATION = "sharingDefaultExpiration"
     const val PREFERENCES_KEY_SHOW_ALL_SONGS_BY_ARTIST = "showAllSongsByArtist"
     const val PREFERENCES_KEY_USE_FIVE_STAR_RATING = "use_five_star_rating"

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Settings.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Settings.kt
@@ -376,6 +376,21 @@ object Settings {
             )
         }
 
+    var shareOnServer: Boolean
+        get() {
+            val preferences = preferences
+            return preferences.getBoolean(Constants.PREFERENCES_KEY_SHARE_ON_SERVER, true)!!
+        }
+        set(shareOnServer) {
+            val preferences = preferences
+            val editor = preferences.edit()
+            editor.putBoolean(
+                Constants.PREFERENCES_KEY_SHARE_ON_SERVER,
+                shareOnServer
+            )
+            editor.apply()
+        }
+
     var defaultShareExpiration: String
         get() {
             val preferences = preferences

--- a/ultrasonic/src/main/res/layout/share_details.xml
+++ b/ultrasonic/src/main/res/layout/share_details.xml
@@ -10,6 +10,14 @@
         a:layout_width="wrap_content"
         a:layout_height="wrap_content">
 
+        <CheckBox
+            a:id="@+id/share_on_server"
+            a:text="@string/share_on_server"
+            a:layout_width="wrap_content"
+            a:layout_height="wrap_content"
+            a:layout_marginTop="4dip"
+            a:layout_marginBottom="4dip" />
+
         <TextView
             a:layout_width="wrap_content"
             a:layout_height="wrap_content"

--- a/ultrasonic/src/main/res/menu/nowplaying.xml
+++ b/ultrasonic/src/main/res/menu/nowplaying.xml
@@ -15,6 +15,11 @@
         app:showAsAction="ifRoom|withText"
         a:title="@string/download.menu_star"/>
     <item
+        a:id="@+id/menu_item_share_song"
+        a:icon="?attr/share"
+        app:showAsAction="ifRoom|withText"
+        a:title="@string/download.share_song"/>
+    <item
         a:id="@+id/menu_item_share"
         a:icon="?attr/share"
         app:showAsAction="ifRoom|withText"

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -353,12 +353,13 @@
     <string name="widget.sdcard_missing">No SD card</string>
     <string name="settings.share_description_default">Default Share Description</string>
     <string name="settings.sharing_title">Sharing</string>
-    <string name="settings.sharing_always_ask_for_details_summary">Always ask for description and expiration when creating a share</string>
+    <string name="settings.sharing_always_ask_for_details_summary">Always ask for description and expiration when creating a share on the server</string>
     <string name="settings.sharing_always_ask_for_details">Always Ask For Details</string>
     <string name="settings.share_expiration_default">Default Expiration Time</string>
     <string name="do_not_show_dialog_again">Do not show dialog again</string>
     <string name="share_set_share_options">Set Share Options</string>
     <string name="share_on_server">Create share on the server</string>
+    <string name="settings.share_on_server_summary">Sharing will create a share on the server and share its URL. If disabled, only the song details are shared</string>
     <string name="no_expiration">No Expiration</string>
     <string name="download.toggle_playlist">Toggle Playlist</string>
     <string name="download.bookmark_set">Set Bookmark</string>

--- a/ultrasonic/src/main/res/values/strings.xml
+++ b/ultrasonic/src/main/res/values/strings.xml
@@ -28,7 +28,9 @@
     <string name="button_bar.playlists">Playlists</string>
     <string name="button_bar.search">Search</string>
     <string name="chat.send_a_message">Send a message</string>
+    <string name="common.album">Album</string>
     <string name="common.appname">Ultrasonic</string>
+    <string name="common.artist">Artist</string>
     <string name="common.cancel">Cancel</string>
     <string name="common.comment">Comment</string>
     <string name="common.confirm">Confirm</string>
@@ -48,6 +50,7 @@
     <string name="common.play_shuffled">Play Shuffled</string>
     <string name="common.public">Public</string>
     <string name="common.save">Save</string>
+    <string name="common.title">Title</string>
     <string name="common.unpin">Unpin</string>
     <string name="common.various_artists">Various Artists</string>
     <string name="delete_playlist">Do you want to delete %1$s</string>
@@ -355,6 +358,7 @@
     <string name="settings.share_expiration_default">Default Expiration Time</string>
     <string name="do_not_show_dialog_again">Do not show dialog again</string>
     <string name="share_set_share_options">Set Share Options</string>
+    <string name="share_on_server">Create share on the server</string>
     <string name="no_expiration">No Expiration</string>
     <string name="download.toggle_playlist">Toggle Playlist</string>
     <string name="download.bookmark_set">Set Bookmark</string>
@@ -377,6 +381,7 @@
     <string name="settings.share_expiration">Time To Expiration</string>
     <string name="download_song_removed">\"%s\" was removed from playlist</string>
     <string name="download.share_playlist">Share Playlist</string>
+    <string name="download.share_song">Share Current Song</string>
     <string name="settings.share_greeting_default">Default Share Greeting</string>
     <string name="share_default_greeting">Check out this music I shared from %s</string>
     <string name="share_via">Share songs via</string>

--- a/ultrasonic/src/main/res/xml/settings.xml
+++ b/ultrasonic/src/main/res/xml/settings.xml
@@ -197,6 +197,11 @@
             a:key="sharingDefaultGreeting"
             a:title="@string/settings.share_greeting_default"
             app:iconSpaceReserved="false"/>
+        <CheckBoxPreference
+            a:defaultValue="true"
+            a:key="sharingCreateOnServer"
+            a:title="@string/share_on_server"
+            app:iconSpaceReserved="false"/>
         <org.moire.ultrasonic.util.TimeSpanPreference
             a:defaultValue="0"
             a:key="sharingDefaultExpiration"

--- a/ultrasonic/src/main/res/xml/settings.xml
+++ b/ultrasonic/src/main/res/xml/settings.xml
@@ -190,10 +190,6 @@
         a:title="@string/settings.sharing_title"
         app:iconSpaceReserved="false">
         <EditTextPreference
-            a:key="sharingDefaultDescription"
-            a:title="@string/settings.share_description_default"
-            app:iconSpaceReserved="false"/>
-        <EditTextPreference
             a:key="sharingDefaultGreeting"
             a:title="@string/settings.share_greeting_default"
             app:iconSpaceReserved="false"/>
@@ -201,17 +197,22 @@
             a:defaultValue="true"
             a:key="sharingCreateOnServer"
             a:title="@string/share_on_server"
-            app:iconSpaceReserved="false"/>
-        <org.moire.ultrasonic.util.TimeSpanPreference
-            a:defaultValue="0"
-            a:key="sharingDefaultExpiration"
-            a:title="@string/settings.share_expiration_default"
+            a:summary="@string/settings.share_on_server_summary"
             app:iconSpaceReserved="false"/>
         <CheckBoxPreference
             a:defaultValue="true"
             a:key="sharingAlwaysAskForDetails"
             a:summary="@string/settings.sharing_always_ask_for_details_summary"
             a:title="@string/settings.sharing_always_ask_for_details"
+            app:iconSpaceReserved="false"/>
+        <EditTextPreference
+            a:key="sharingDefaultDescription"
+            a:title="@string/settings.share_description_default"
+            app:iconSpaceReserved="false"/>
+        <org.moire.ultrasonic.util.TimeSpanPreference
+            a:defaultValue="0"
+            a:key="sharingDefaultExpiration"
+            a:title="@string/settings.share_expiration_default"
             app:iconSpaceReserved="false"/>
     </PreferenceCategory>
     <PreferenceCategory


### PR DESCRIPTION
Closes #542
Added a new checkbox which can be used to turn off share creation on the server. This only works when sharing single songs. In this case only the song details will be shared, for example by using an instant messaging app.

Also added an option to the Player Fragment's menu to share the currently playing song. This can be used to quickly share a nice song with your friends during listening :)
