### PR TITLE
Update Gradle and ktlint

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,13 +3,13 @@ ext.versions = [
         targetSdk            : 29,
         compileSdk           : 29,
         // You need to run ./gradlew wrapper after updating the version
-        gradle               : '7.0',
+        gradle               : '7.2',
 
         navigation           : "2.3.5",
         gradlePlugin         : "4.2.2",
         androidxcore         : "1.5.0",
         ktlint               : "0.37.1",
-        ktlintGradle         : "9.2.1",
+        ktlintGradle         : "10.2.0",
         detekt               : "1.18.1",
         jacoco               : "0.8.7",
         preferences          : "1.1.1",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle_scripts/kotlin-module-bootstrap.gradle
+++ b/gradle_scripts/kotlin-module-bootstrap.gradle
@@ -32,9 +32,9 @@ ext {
 
 jacocoTestReport {
     reports {
-        html.enabled true
-        csv.enabled false
-        xml.enabled true
+        html.required = true
+        xml.required = false
+        csv.required = false
     }
 
     afterEvaluate {


### PR DESCRIPTION
This fixes the annyoing ktlin warning:

`Gradle detected a problem with the following location: '/ultrasonic/ultrasonic/src/test/java'. Reason: Task ':ultrasonic:ktlintTestSourceSetFormat' uses this output of task ':ultrasonic:ktlintKotlinScriptFormat' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.`