### PR TITLE
Updated custom cache location handling to remove isUri

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SettingsFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/SettingsFragment.kt
@@ -50,7 +50,6 @@ import org.moire.ultrasonic.util.Storage
 import org.moire.ultrasonic.util.TimeSpanPreference
 import org.moire.ultrasonic.util.TimeSpanPreferenceDialogFragmentCompat
 import org.moire.ultrasonic.util.Util.toast
-import org.moire.ultrasonic.util.isUri
 import timber.log.Timber
 
 /**
@@ -171,31 +170,36 @@ class SettingsFragment :
      */
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
         if (
-            requestCode != SELECT_CACHE_ACTIVITY ||
-            resultCode != Activity.RESULT_OK ||
-            resultData == null
-        ) return
+            requestCode == SELECT_CACHE_ACTIVITY &&
+            resultCode == Activity.RESULT_OK &&
+            resultData != null
+        ) {
+            val read = (resultData.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION) != 0
+            val write = (resultData.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION) != 0
+            val persist = (resultData.flags and Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION) != 0
 
-        val read = (resultData.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION) != 0
-        val write = (resultData.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION) != 0
-        val persist = (resultData.flags and Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION) != 0
+            if (read && write && persist) {
+                if (resultData.data != null) {
+                    // The result data contains a URI for the document or directory that
+                    // the user selected.
+                    val uri = resultData.data!!
+                    val contentResolver = UApp.applicationContext().contentResolver
 
-        if (!read || !write || !persist) {
+                    contentResolver.takePersistableUriPermission(uri, RW_FLAG)
+                    setCacheLocation(uri.toString())
+                    setupCacheLocationPreference()
+                    return
+                }
+            }
             ErrorDialog.Builder(context)
                 .setMessage(R.string.settings_cache_location_error)
                 .show()
-            return
         }
 
-        // The result data contains a URI for the document or directory that
-        // the user selected.
-        resultData.data?.also { uri ->
-            // Perform operations on the document using its URI.
-            val contentResolver = UApp.applicationContext().contentResolver
-
-            contentResolver.takePersistableUriPermission(uri, RW_FLAG)
-
-            setCacheLocation(uri.toString())
+        if (Settings.cacheLocationUri == "") {
+            Settings.customCacheLocation = false
+            customCacheLocation?.isChecked = false
+            setupCacheLocationPreference()
         }
     }
 
@@ -234,7 +238,12 @@ class SettingsFragment :
                 RxBus.themeChangedEventPublisher.onNext(Unit)
             }
             Constants.PREFERENCES_KEY_CUSTOM_CACHE_LOCATION -> {
-                setupCacheLocationPreference()
+                if (Settings.customCacheLocation) {
+                    selectCacheLocation()
+                } else {
+                    if (Settings.cacheLocationUri != "") setCacheLocation("")
+                    setupCacheLocationPreference()
+                }
             }
         }
     }
@@ -259,34 +268,32 @@ class SettingsFragment :
     }
 
     private fun setupCacheLocationPreference() {
-        val isDefault = Settings.cacheLocation == defaultMusicDirectory.path
-
         if (!Settings.customCacheLocation) {
             cacheLocation?.isVisible = false
-            if (!isDefault) setCacheLocation(defaultMusicDirectory.path)
             return
         }
 
         cacheLocation?.isVisible = true
-        val uri = Uri.parse(Settings.cacheLocation)
+        val uri = Uri.parse(Settings.cacheLocationUri)
         cacheLocation!!.summary = uri.path
-        cacheLocation!!.onPreferenceClickListener =
-            Preference.OnPreferenceClickListener {
+        cacheLocation!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            selectCacheLocation()
+            true
+        }
+    }
 
-                // Choose a directory using the system's file picker.
-                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+    private fun selectCacheLocation() {
+        // Choose a directory using the system's file picker.
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
 
-                if (!isDefault && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, defaultMusicDirectory.path)
-                }
+        if (Settings.cacheLocationUri != "" && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, defaultMusicDirectory.path)
+        }
 
-                intent.addFlags(RW_FLAG)
-                intent.addFlags(PERSISTABLE_FLAG)
+        intent.addFlags(RW_FLAG)
+        intent.addFlags(PERSISTABLE_FLAG)
 
-                startActivityForResult(intent, SELECT_CACHE_ACTIVITY)
-
-                true
-            }
+        startActivityForResult(intent, SELECT_CACHE_ACTIVITY)
     }
 
     private fun setupBluetoothDevicePreferences() {
@@ -393,7 +400,6 @@ class SettingsFragment :
         sharingDefaultExpiration!!.summary = sharingDefaultExpiration!!.text
         sharingDefaultDescription!!.summary = sharingDefaultDescription!!.text
         sharingDefaultGreeting!!.summary = sharingDefaultGreeting!!.text
-        cacheLocation!!.summary = Settings.cacheLocation
         if (!mediaButtonsEnabled!!.isChecked) {
             lockScreenEnabled!!.isChecked = false
             lockScreenEnabled!!.isEnabled = false
@@ -438,15 +444,16 @@ class SettingsFragment :
     }
 
     private fun setCacheLocation(path: String) {
-        if (path.isUri()) {
+        if (path != "") {
             val uri = Uri.parse(path)
             cacheLocation!!.summary = uri.path ?: ""
         }
 
-        Settings.cacheLocation = path
+        Settings.cacheLocationUri = path
 
         // Clear download queue.
         mediaPlayerControllerLazy.value.clear()
+        mediaPlayerControllerLazy.value.clearCaches()
         Storage.reset()
     }
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/Downloader.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/Downloader.kt
@@ -44,6 +44,7 @@ class Downloader(
 
     private val jukeboxMediaPlayer: JukeboxMediaPlayer by inject()
 
+    // TODO is this cache necessary?
     private val downloadFileCache = LRUCache<MusicDirectory.Entry, DownloadFile>(100)
 
     private var executorService: ScheduledExecutorService? = null
@@ -280,6 +281,11 @@ class Downloader(
     // Public facing playlist (immutable)
     @Synchronized
     fun getPlaylist(): List<DownloadFile> = playlist
+
+    @Synchronized
+    fun clearDownloadFileCache() {
+        downloadFileCache.clear()
+    }
 
     @Synchronized
     fun clearPlaylist() {

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerController.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/MediaPlayerController.kt
@@ -281,6 +281,11 @@ class MediaPlayerController(
     }
 
     @Synchronized
+    fun clearCaches() {
+        downloader.clearDownloadFileCache()
+    }
+
+    @Synchronized
     fun clearIncomplete() {
         reset()
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Settings.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Settings.kt
@@ -112,9 +112,8 @@ object Settings {
     )
 
     @JvmStatic
-    var cacheLocation by StringSetting(
-        Constants.PREFERENCES_KEY_CACHE_LOCATION,
-        FileUtil.defaultMusicDirectory.path
+    var cacheLocationUri by StringSetting(
+        Constants.PREFERENCES_KEY_CACHE_LOCATION, ""
     )
 
     @JvmStatic

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Storage.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/util/Storage.kt
@@ -31,7 +31,8 @@ object Storage {
         Timber.i("StorageFile caches were reset")
         val root = getRoot()
         if (root == null) {
-            Settings.cacheLocation = FileUtil.defaultMusicDirectory.path
+            Settings.customCacheLocation = false
+            Settings.cacheLocationUri = ""
             Util.toast(UApp.applicationContext(), R.string.settings_cache_location_error)
         }
     }
@@ -70,22 +71,16 @@ object Storage {
     }
 
     private fun getRoot(): AbstractFile? {
-        return if (Settings.cacheLocation.isUri()) {
+        return if (Settings.customCacheLocation) {
             val documentFile = DocumentFile.fromTreeUri(
                 UApp.applicationContext(),
-                Uri.parse(Settings.cacheLocation)
+                Uri.parse(Settings.cacheLocationUri)
             ) ?: return null
             if (!documentFile.exists()) return null
             StorageFile(null, documentFile.uri, documentFile.name!!, documentFile.isDirectory)
         } else {
-            val file = File(Settings.cacheLocation)
-            if (!file.exists()) return null
+            val file = File(FileUtil.defaultMusicDirectory.path)
             JavaFile(null, file)
         }
     }
-}
-
-fun String.isUri(): Boolean {
-    // TODO is there a better way to tell apart a path and an URI?
-    return this.contains(':')
 }


### PR DESCRIPTION
Fixes #645 

There was another problem which caused an exception: when the cache location was changed, old downloadFile paths may still  remained in the downloadFileCache. 