### PR TITLE
Update OkHttp to 4.9.1

### DIFF
--- a/core/subsonic-api/src/integrationTest/kotlin/org/moire/ultrasonic/api/subsonic/CommonFunctions.kt
+++ b/core/subsonic-api/src/integrationTest/kotlin/org/moire/ultrasonic/api/subsonic/CommonFunctions.kt
@@ -9,6 +9,7 @@ import java.util.TimeZone
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.Okio
+import okio.source
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should not be`
@@ -40,12 +41,12 @@ fun MockWebServer.enqueueResponse(resourceName: String) {
 }
 
 fun Any.loadJsonResponse(name: String): String {
-    val source = Okio.buffer(Okio.source(javaClass.classLoader.getResourceAsStream(name)))
+    val source = Okio.buffer(javaClass.classLoader.getResourceAsStream(name).source())
     return source.readString(Charset.forName("UTF-8"))
 }
 
 fun Any.loadResourceStream(name: String): InputStream {
-    val source = Okio.buffer(Okio.source(javaClass.classLoader.getResourceAsStream(name)))
+    val source = Okio.buffer(javaClass.classLoader.getResourceAsStream(name).source())
     return source.inputStream()
 }
 

--- a/core/subsonic-api/src/integrationTest/kotlin/org/moire/ultrasonic/api/subsonic/CommonFunctions.kt
+++ b/core/subsonic-api/src/integrationTest/kotlin/org/moire/ultrasonic/api/subsonic/CommonFunctions.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 import java.util.TimeZone
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import okio.Okio
+import okio.buffer
 import okio.source
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should contain`
@@ -41,12 +41,12 @@ fun MockWebServer.enqueueResponse(resourceName: String) {
 }
 
 fun Any.loadJsonResponse(name: String): String {
-    val source = Okio.buffer(javaClass.classLoader.getResourceAsStream(name).source())
+    val source = javaClass.classLoader.getResourceAsStream(name)!!.source().buffer()
     return source.readString(Charset.forName("UTF-8"))
 }
 
 fun Any.loadResourceStream(name: String): InputStream {
-    val source = Okio.buffer(javaClass.classLoader.getResourceAsStream(name).source())
+    val source = javaClass.classLoader.getResourceAsStream(name)!!.source().buffer()
     return source.inputStream()
 }
 

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/Extensions.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/Extensions.kt
@@ -17,8 +17,8 @@ fun Response<out ResponseBody>.toStreamResponse(): StreamResponse {
         val contentType = responseBody?.contentType()
         if (
             contentType != null &&
-            contentType.type().equals("application", true) &&
-            contentType.subtype().equals("json", true)
+            contentType.type.equals("application", true) &&
+            contentType.subtype.equals("json", true)
         ) {
             val error = SubsonicAPIClient.jacksonMapper.readValue<SubsonicResponse>(
                 responseBody.byteStream()
@@ -40,7 +40,7 @@ fun Response<out ResponseBody>.toStreamResponse(): StreamResponse {
  * It creates Exceptions from the results returned by the Subsonic API
  */
 @Suppress("ThrowsCount")
-fun <T : SubsonicResponse> Response<out T>.throwOnFailure(): Response<out T> {
+fun <T : SubsonicResponse> Response<T>.throwOnFailure(): Response<T> {
     val response = this
 
     if (response.isSuccessful && response.body()!!.status === SubsonicResponse.Status.OK) {

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIClient.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIClient.kt
@@ -68,7 +68,7 @@ class SubsonicAPIClient(
         .addInterceptor { chain ->
             // Adds default request params
             val originalRequest = chain.request()
-            val newUrl = originalRequest.url().newBuilder()
+            val newUrl = originalRequest.url.newBuilder()
                 .addQueryParameter("u", config.username)
                 .addQueryParameter("c", config.clientID)
                 .addQueryParameter("f", "json")

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/PasswordHexInterceptor.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/PasswordHexInterceptor.kt
@@ -18,7 +18,7 @@ class PasswordHexInterceptor(private val password: String) : Interceptor {
 
     override fun intercept(chain: Chain): Response {
         val originalRequest = chain.request()
-        val updatedUrl = originalRequest.url().newBuilder()
+        val updatedUrl = originalRequest.url.newBuilder()
             .addEncodedQueryParameter("p", passwordHex).build()
         return chain.proceed(originalRequest.newBuilder().url(updatedUrl).build())
     }

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/PasswordMD5Interceptor.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/PasswordMD5Interceptor.kt
@@ -21,7 +21,7 @@ class PasswordMD5Interceptor(private val password: String) : Interceptor {
     override fun intercept(chain: Chain): Response {
         val originalRequest = chain.request()
         val salt = getSalt()
-        val updatedUrl = originalRequest.url().newBuilder()
+        val updatedUrl = originalRequest.url.newBuilder()
             .addQueryParameter("t", getPasswordMD5Hash(salt))
             .addQueryParameter("s", salt)
             .build()

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/RangeHeaderInterceptor.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/RangeHeaderInterceptor.kt
@@ -19,7 +19,7 @@ internal const val TIMEOUT_MILLIS_PER_OFFSET_BYTE = 0.02
 internal class RangeHeaderInterceptor : Interceptor {
     override fun intercept(chain: Chain): Response {
         val originalRequest = chain.request()
-        val headers = originalRequest.headers()
+        val headers = originalRequest.headers
         return if (headers.names().contains("Range")) {
             val offsetValue = headers["Range"] ?: "0"
             val offset = "bytes=$offsetValue-"

--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/VersionInterceptor.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/interceptors/VersionInterceptor.kt
@@ -18,7 +18,7 @@ internal class VersionInterceptor(
         val newRequest = originalRequest.newBuilder()
             .url(
                 originalRequest
-                    .url()
+                    .url
                     .newBuilder()
                     .addQueryParameter("v", protocolVersion.restApiVersion)
                     .build()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,9 +22,9 @@ kotlin                 = "1.6.10"
 kotlinxCoroutines      = "1.6.0-native-mt"
 viewModelKtx           = "2.3.0"
 
-retrofit               = "2.6.4"
-jackson                = "2.9.5"
-okhttp                 = "3.12.13"
+retrofit               = "2.9.0"
+jackson                = "2.10.1"
+okhttp                 = "4.9.1"
 koin                   = "3.0.2"
 picasso                = "2.71828"
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/imageloader/AvatarRequestHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/imageloader/AvatarRequestHandler.kt
@@ -4,7 +4,7 @@ import com.squareup.picasso.Picasso
 import com.squareup.picasso.Request
 import com.squareup.picasso.RequestHandler
 import java.io.IOException
-import okio.Okio
+import okio.source
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIClient
 
 /**
@@ -29,7 +29,7 @@ class AvatarRequestHandler(
         if (response.hasError() || response.stream == null) {
             throw IOException("${response.apiError}")
         } else {
-            return Result(Okio.source(response.stream!!), Picasso.LoadedFrom.NETWORK)
+            return Result(response.stream!!.source(), Picasso.LoadedFrom.NETWORK)
         }
     }
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/imageloader/CoverArtRequestHandler.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/imageloader/CoverArtRequestHandler.kt
@@ -5,7 +5,7 @@ import com.squareup.picasso.Picasso.LoadedFrom.NETWORK
 import com.squareup.picasso.Request
 import com.squareup.picasso.RequestHandler
 import java.io.IOException
-import okio.Okio
+import okio.source
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIClient
 import org.moire.ultrasonic.api.subsonic.toStreamResponse
 import org.moire.ultrasonic.util.FileUtil.SUFFIX_LARGE
@@ -44,7 +44,7 @@ class CoverArtRequestHandler(private val client: SubsonicAPIClient) : RequestHan
 
         // Handle the response
         if (!response.hasError() && response.stream != null) {
-            return Result(Okio.source(response.stream!!), NETWORK)
+            return Result(response.stream!!.source(), NETWORK)
         }
 
         // Throw an error if still not successful

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/service/RESTMusicService.kt
@@ -10,12 +10,11 @@ import java.io.IOException
 import java.io.InputStream
 import okhttp3.Protocol
 import okhttp3.Response
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.moire.ultrasonic.api.subsonic.ApiNotSupportedException
 import org.moire.ultrasonic.api.subsonic.SubsonicAPIClient
 import org.moire.ultrasonic.api.subsonic.models.AlbumListType.Companion.fromName
 import org.moire.ultrasonic.api.subsonic.models.JukeboxAction
-import org.moire.ultrasonic.api.subsonic.response.StreamResponse
 import org.moire.ultrasonic.api.subsonic.throwOnFailure
 import org.moire.ultrasonic.api.subsonic.toStreamResponse
 import org.moire.ultrasonic.data.ActiveServerProvider
@@ -425,14 +424,13 @@ open class RESTMusicService(
         save: Boolean
     ): Pair<InputStream, Boolean> {
         val songOffset = if (offset < 0) 0 else offset
-        lateinit var response: StreamResponse
 
         // Use semantically correct call
-        if (save) {
-            response = API.download(song.id, maxBitrate, offset = songOffset)
+        val response = if (save) {
+            API.download(song.id, maxBitrate, offset = songOffset)
                 .execute().toStreamResponse()
         } else {
-            response = API.stream(song.id, maxBitrate, offset = songOffset)
+            API.stream(song.id, maxBitrate, offset = songOffset)
                 .execute().toStreamResponse()
         }
 
@@ -463,7 +461,7 @@ open class RESTMusicService(
             // Returns a dummy response
             Response.Builder()
                 .code(100)
-                .body(ResponseBody.create(null, ""))
+                .body("".toResponseBody(null))
                 .protocol(Protocol.HTTP_2)
                 .message("Empty response")
                 .request(chain.request())
@@ -480,7 +478,7 @@ open class RESTMusicService(
         val response = client.newCall(request).execute()
 
         // The complete url :)
-        val url = response.request().url()
+        val url = response.request.url
 
         return url.toString()
     }

--- a/ultrasonic/src/test/kotlin/org/moire/ultrasonic/imageloader/CommonFunctions.kt
+++ b/ultrasonic/src/test/kotlin/org/moire/ultrasonic/imageloader/CommonFunctions.kt
@@ -1,9 +1,10 @@
 package org.moire.ultrasonic.imageloader
 
 import java.io.InputStream
-import okio.Okio
+import okio.buffer
+import okio.source
 
 fun Any.loadResourceStream(name: String): InputStream {
-    val source = Okio.buffer(Okio.source(javaClass.classLoader!!.getResourceAsStream(name)))
+    val source = javaClass.classLoader!!.getResourceAsStream(name).source().buffer()
     return source.inputStream()
 }


### PR DESCRIPTION
We were very behind on OkHttp versions because we needed to support low APIs. We can upgrade now that the minApi is higher