### PR TITLE
Updated Gradle to fix R8 bug with Kotlin 1.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 gradle                 = "7.3.2"
 
 navigation             = "2.3.5"
-gradlePlugin           = "7.0.4"
+gradlePlugin           = "7.1.1"
 androidxcore           = "1.6.0"
 ktlint                 = "0.43.2"
 ktlintGradle           = "10.2.0"

--- a/ultrasonic/build.gradle
+++ b/ultrasonic/build.gradle
@@ -14,8 +14,8 @@ android {
 
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
+        resConfigs 'cs', 'de', 'en', 'es', 'fr', 'hu', 'it', 'nl', 'pl', 'pt', 'pt-rBR', 'ru', 'zh-rCN', 'zh-rTW'
 
-        resConfigs "cs", "de", "en", "es", "fr", "hu", "it", "nl", "pl", "pt", "pt-rBR", "ru", "zh-rCN", "zh-rTW"
     }
 
     buildTypes {
@@ -40,20 +40,12 @@ android {
         main.java.srcDirs += "${projectDir}/src/main/kotlin"
         test.java.srcDirs += "${projectDir}/src/test/kotlin"
     }
-
     packagingOptions {
-        exclude 'META-INF/LICENSE'
+        resources {
+            excludes += ['META-INF/LICENSE']
+        }
     }
 
-    lintOptions {
-        baselineFile file("lint-baseline.xml")
-        ignore 'MissingTranslation'
-        ignore 'UnusedQuantity'
-        warning 'ImpliedQuantity'
-        disable 'IconMissingDensityFolder', "VectorPath"
-        abortOnError true
-        warningsAsErrors true
-    }
 
     kotlinOptions {
         jvmTarget = "1.8"
@@ -73,6 +65,13 @@ android {
         arguments {
             arg("room.schemaLocation", "$buildDir/schemas".toString())
         }
+    }
+    lint {
+        abortOnError true
+        disable 'IconMissingDensityFolder', 'VectorPath'
+        ignore 'MissingTranslation', 'UnusedQuantity'
+        warning 'ImpliedQuantity'
+        warningsAsErrors true
     }
 
 }

--- a/ultrasonic/build.gradle
+++ b/ultrasonic/build.gradle
@@ -67,11 +67,12 @@ android {
         }
     }
     lint {
+        baseline = file("lint-baseline.xml")
         abortOnError true
-        disable 'IconMissingDensityFolder', 'VectorPath'
-        ignore 'MissingTranslation', 'UnusedQuantity'
-        warning 'ImpliedQuantity'
         warningsAsErrors true
+        disable 'IconMissingDensityFolder', 'VectorPath'
+        ignore 'MissingTranslation', 'UnusedQuantity', 'MissingQuantity'
+        warning 'ImpliedQuantity'
     }
 
 }

--- a/ultrasonic/src/main/AndroidManifest.xml
+++ b/ultrasonic/src/main/AndroidManifest.xml
@@ -40,7 +40,6 @@
 
         <activity android:name=".activity.NavigationActivity"
             android:configChanges="orientation|keyboardHidden"
-            android:label="@string/common.appname"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This relates to the issue found in #688, in the release version of 3.1.0.
The problem was that minify/R8 removed some metadata which made the deserialization of responses fail.

I was in a bit of a panic, because this was an obscure error, but the fix seems to be simple enough: the new gradle version contains a fixed R8 which works correctly with Kotlin 1.6.

@ogarcia if you have time, could you please release a patched version? This works now with a release build on my pc, but I want to test a real release which was built by the CI too...