### PR TITLE
TrackCollectionFragment: fix play all button

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/TrackCollectionFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/TrackCollectionFragment.kt
@@ -276,7 +276,7 @@ open class TrackCollectionFragment : MultiListFragment<MusicDirectory.Child>() {
         var hasSubFolders = false
 
         for (item in viewAdapter.getCurrentList()) {
-            if (item is MusicDirectory.Entry && item.isDirectory) {
+            if (item is MusicDirectory.Child && item.isDirectory) {
                 hasSubFolders = true
                 break
             }


### PR DESCRIPTION
This is a bugfix. Whenever I press the play all button on a folder with no tracks, it would load an empty playlist instead of recursively adding all the subfolders.

It looks like the folders aren't `MusicDirectory.Entry` but `MusicDirectory.Album`.

Note: I am using airsonic as my backend.