### PR TITLE
Fixed Search result to return Artist correctly when ID3 tags are turned off

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/domain/APISearchConverter.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/domain/APISearchConverter.kt
@@ -13,7 +13,7 @@ fun APISearchResult.toDomainEntity(): SearchResult = SearchResult(
 )
 
 fun SearchTwoResult.toDomainEntity(): SearchResult = SearchResult(
-    this.artistList.map { it.toDomainEntity() },
+    this.artistList.map { it.toIndexEntity() },
     this.albumList.map { it.toDomainEntity() },
     this.songList.map { it.toTrackEntity() }
 )

--- a/ultrasonic/src/test/kotlin/org/moire/ultrasonic/domain/APISearchConverterTest.kt
+++ b/ultrasonic/src/test/kotlin/org/moire/ultrasonic/domain/APISearchConverterTest.kt
@@ -50,7 +50,7 @@ class APISearchConverterTest {
 
         with(convertedEntity) {
             artists.size `should be equal to` entity.artistList.size
-            artists[0] `should be equal to` entity.artistList[0].toDomainEntity()
+            artists[0] `should be equal to` entity.artistList[0].toIndexEntity()
             albums.size `should be equal to` entity.albumList.size
             albums[0] `should be equal to` entity.albumList[0].toDomainEntity()
             songs.size `should be equal to` entity.songList.size


### PR DESCRIPTION
Fixes #673 
I think this was an old bug, at least the Search2 function (which is called for search when ID3 tags are off) returned an Artist instead of an Index before the RestMusicService was converted to Kotlin.
Without the ID3 tags, it should return an Index, so later the AlbumListFragment can load the albums using the correct Subsonic API function.