### PR TITLE
Don't manage ID manually, but use autoGenerate to ensure uniqueness

### DIFF
--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/AppDatabase.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/AppDatabase.kt
@@ -10,9 +10,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
  * This could be settings or data that are not specific to any remote music database
  */
 @Database(
-    entities = [ServerSetting::class],
-    version = 4,
-    exportSchema = true
+        entities = [ServerSetting::class],
+        version = 5,
+        exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
 

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSetting.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSetting.kt
@@ -19,7 +19,8 @@ import androidx.room.PrimaryKey
  */
 @Entity
 data class ServerSetting(
-    @PrimaryKey var id: Int,
+    // Default ID is 0, which will trigger SQLite to generate a unique ID.
+    @PrimaryKey(autoGenerate = true) var id: Int = 0,
     @ColumnInfo(name = "index") var index: Int,
     @ColumnInfo(name = "name") var name: String,
     @ColumnInfo(name = "url") var url: String,
@@ -37,6 +38,6 @@ data class ServerSetting(
     @ColumnInfo(name = "podcastSupport") var podcastSupport: Boolean? = null
 ) {
     constructor() : this (
-        -1, 0, "", "", null, "", "", false, false, false, null, null
+        0, 0, "", "", null, "", "", false, false, false, null, null
     )
 }

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSettingDao.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/data/ServerSettingDao.kt
@@ -70,12 +70,6 @@ interface ServerSettingDao {
     fun liveServerCount(): LiveData<Int?>
 
     /**
-     * Retrieves the greatest value of the Id column in the table
-     */
-    @Query("SELECT MAX([id]) FROM serverSetting")
-    suspend fun getMaxId(): Int?
-
-    /**
      * Retrieves the greatest value of the Index column in the table
      */
     @Query("SELECT MAX([index]) FROM serverSetting")

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/model/ServerSettingsModel.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/model/ServerSettingsModel.kt
@@ -127,7 +127,6 @@ class ServerSettingsModel(
 
         appScope.launch {
             serverSetting.index = (repository.count() ?: 0) + 1
-            serverSetting.id = (repository.getMaxId() ?: 0) + 1
             repository.insert(serverSetting)
             Timber.d("saveNewItem saved server setting: $serverSetting")
         }
@@ -142,12 +141,11 @@ class ServerSettingsModel(
 
         runBlocking {
             demo.index = (repository.count() ?: 0) + 1
-            demo.id = (repository.getMaxId() ?: 0) + 1
             repository.insert(demo)
             Timber.d("Added demo server")
         }
 
-        return demo.id
+        return demo.index
     }
 
     /**


### PR DESCRIPTION
See #718  This is step 3

Make server id unique. Needed to reference the servers from which tracks or albums are cached precisely.