### PR TITLE
Support HTTP basic authentication

### DIFF
--- a/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIClient.kt
+++ b/core/subsonic-api/src/main/kotlin/org/moire/ultrasonic/api/subsonic/SubsonicAPIClient.kt
@@ -8,6 +8,7 @@ import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
+import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
 import okhttp3.logging.HttpLoggingInterceptor
@@ -73,7 +74,19 @@ class SubsonicAPIClient(
                 .addQueryParameter("c", config.clientID)
                 .addQueryParameter("f", "json")
                 .build()
-            chain.proceed(originalRequest.newBuilder().url(newUrl).build())
+            val newRequestBuilder = originalRequest.newBuilder().url(newUrl)
+            if (originalRequest.url.username.isNotEmpty() &&
+                originalRequest.url.password.isNotEmpty()
+            ) {
+                newRequestBuilder.addHeader(
+                    "Authorization",
+                    Credentials.basic(
+                        originalRequest.url.username,
+                        originalRequest.url.password
+                    )
+                )
+            }
+            chain.proceed(newRequestBuilder.build())
         }
         .addInterceptor(versionInterceptor)
         .addInterceptor(proxyPasswordInterceptor)

--- a/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/EditServerFragment.kt
+++ b/ultrasonic/src/main/kotlin/org/moire/ultrasonic/fragment/EditServerFragment.kt
@@ -298,7 +298,6 @@ class EditServerFragment : Fragment(), OnBackPressedHandler {
                 url = URL(urlString)
                 if (
                     urlString != urlString.trim(' ') ||
-                    urlString.contains("@") ||
                     url.host.isNullOrBlank()
                 ) {
                     throw MalformedURLException()


### PR DESCRIPTION
You can now specify HTTP basic authentication credentials in the server URL, e.g. `https://myuser:mypassword@music.server.com`.

Tested on https://github.com/navidrome/navidrome/releases/tag/v0.47.5 behind Nginx with basic HTTP authentication enabled.

closes #351 